### PR TITLE
Hide handle to process as private

### DIFF
--- a/include/Framework/EventProcessor.h
+++ b/include/Framework/EventProcessor.h
@@ -172,13 +172,13 @@ namespace ldmx {
              * Get the current logging frequency from the process
              * @return int frequency logging should occurr
              */
-            int getLogFrequency() const { return process_.getLogFrequency(); }
+            int getLogFrequency() const;
 
             /**
              * Get the run number from the process
              * @return int run number
              */
-            int getRunNumber() const { return process_.getRunNumber(); }
+            int getRunNumber() const;
     
             /**
              * Internal function which is part of the EventProcessorFactory machinery.

--- a/include/Framework/EventProcessor.h
+++ b/include/Framework/EventProcessor.h
@@ -167,6 +167,18 @@ namespace ldmx {
              * @param purposeString A purpose string which can be used in the skim control configuration
              */
             void setStorageHint(ldmx::StorageControlHint hint, const std::string& purposeString);
+
+            /**
+             * Get the current logging frequency from the process
+             * @return int frequency logging should occurr
+             */
+            int getLogFrequency() const { return process_.getLogFrequency(); }
+
+            /**
+             * Get the run number from the process
+             * @return int run number
+             */
+            int getRunNumber() const { return process_.getRunNumber(); }
     
             /**
              * Internal function which is part of the EventProcessorFactory machinery.
@@ -190,9 +202,6 @@ namespace ldmx {
              */
             void abortEvent() { throw AbortEventException(); }
 
-            /** Handle to the Process. */
-            Process& process_;
-
             /// Interface class for making and filling histograms
             HistogramHelper histograms_;
 
@@ -203,6 +212,9 @@ namespace ldmx {
             logging::logger theLog_;
 
         private:
+
+            /** Handle to the Process. */
+            Process& process_;
 
             /** The name of the EventProcessor. */
             std::string name_;

--- a/include/Framework/Process.h
+++ b/include/Framework/Process.h
@@ -56,12 +56,10 @@ namespace ldmx {
             }
 
             /**
-             * Set the run number to be used when initiating new events from the job
-             * @param run Run number to use
+             * Get the run number to be used when initiating new events from the job
+             * @return int Run number
              */
-            void setRunNumber(int run) {
-                runForGeneration_=run;
-            }
+            int getRunNumber() const { return runForGeneration_; }
 
             /**
              * Get the frequency with which the event information is printed.

--- a/src/EventProcessor.cxx
+++ b/src/EventProcessor.cxx
@@ -23,6 +23,14 @@ namespace ldmx {
     void EventProcessor::setStorageHint(ldmx::StorageControlHint hint, const std::string& purposeString) {
         process_.getStorageController().addHint(name_,hint,purposeString);
     }
+
+    int EventProcessor::getLogFrequency() const {
+        return process_.getLogFrequency();
+    }
+
+    int EventProcessor::getRunNumber() const {
+        return process_.getRunNumber();
+    }
   
     void EventProcessor::declare(const std::string& classname, int classtype,EventProcessorMaker* maker) {
         EventProcessorFactory::getInstance().registerEventProcessor(classname, classtype, maker);


### PR DESCRIPTION
This makes the handle to the process safer because the Framework module "knows" exactly what everyone is doing with the handle to the process (there has to be a specific member function in `EventProcessor` doing the requested behavior).