### PR TITLE
add in dummy process maker

### DIFF
--- a/include/Framework/Process.h
+++ b/include/Framework/Process.h
@@ -91,6 +91,28 @@ namespace ldmx {
              * Access the storage control unit for this process
              */
             StorageControl& getStorageController() { return m_storageController; }
+
+            /**
+             * Get a dummy process
+             *
+             * This function returns an instance of this class without
+             * any configuration. This is only helpful in the use case
+             * where the user is writing a test for a processor and
+             * needs to pass a Process object to the processor's constructor.
+             *
+             * @return Process without any configuration
+             */
+            static Process getDummy() {
+                return std::move(Process());
+            }
+
+        private:
+
+            /**
+             * Private dummy constructor
+             * We hide it here because it shouldn't be used anywhere else.
+             */
+            Process() { /** nothing on purpose */ }
     
         private:
 


### PR DESCRIPTION
This resolves #10 by hiding a private constructor and then providing a static member that can create a "dummy" Process that has no configuration.