### PR TITLE
Remove need for include.py for EventProcessors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,10 @@ find_package(Boost REQUIRED COMPONENTS system log filesystem thread chrono atomi
 
 # Setup the library
 setup_library(name Framework
-              dependencies Python3::Python 
-                           ROOT::Hist ROOT::TreePlayer ROOT::MathCore ROOT::Physics
-                           DARK::Event 
-                           Boost::log Boost::atomic Boost::regex
+              dependencies Python3::Python ROOT::Hist ROOT::TreePlayer
+                           DARK::Event Boost::log Boost::atomic Boost::regex
               python_install_path ${PYTHON_INSTALL_PREFIX}
+              python_root_module_name LDMX
 )
 
 # Compiling the Framework library requires features introduced by the cpp 17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ setup_library(name Framework
               dependencies Python3::Python ROOT::Hist ROOT::TreePlayer
                            DARK::Event Boost::log Boost::atomic Boost::regex
               python_install_path ${PYTHON_INSTALL_PREFIX}
-              python_root_module_name LDMX
 )
 
 # Compiling the Framework library requires features introduced by the cpp 17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,10 @@ find_package(Boost REQUIRED COMPONENTS system log filesystem thread chrono atomi
 
 # Setup the library
 setup_library(name Framework
-              dependencies Python3::Python ROOT::Hist ROOT::TreePlayer
-                           DARK::Event Boost::log Boost::atomic Boost::regex
+              dependencies Python3::Python 
+                           ROOT::Hist ROOT::TreePlayer
+                           DARK::Event 
+                           Boost::log Boost::atomic Boost::regex
               python_install_path ${PYTHON_INSTALL_PREFIX}
 )
 

--- a/python/ldmxcfg.py
+++ b/python/ldmxcfg.py
@@ -36,7 +36,7 @@ class EventProcessor:
         self.className=className
         self.histograms=[]
 
-        Process.lastProcess.addLibrary( '${CMAKE_INSTALL_PREFIX}/lib/lib%s.so'%moduleName )
+        Process.addLibrary( '${CMAKE_INSTALL_PREFIX}/lib/lib%s.so'%moduleName )
 
     def build1DHistogram(self, name, xlabel, bins, xmin = None, xmax = None):
         """Make a 1D histogram 
@@ -141,8 +141,8 @@ class Producer(EventProcessor):
     LDMX.Framwork.ldmxcfg.EventProcessor : base class
     """
 
-    def __init__(self, instanceName, className):
-        super().__init__(instanceName,className)
+    def __init__(self, instanceName, className, moduleName):
+        super().__init__(instanceName,className, moduleName)
 
     def __str__(self) :
         """Stringify this Producer, creates a message with all the internal parameters.
@@ -171,8 +171,8 @@ class Analyzer(EventProcessor):
     LDMX.Framework.ldmxcfg.EventProcessor : base class
     """
 
-    def __init__(self, instanceName, className):
-        super().__init__(instanceName,className)
+    def __init__(self, instanceName, className, moduleName):
+        super().__init__(instanceName,className, moduleName)
 
     def __str__(self) :
         """Stringify this Analyzer, creates a message with all the internal parameters.
@@ -289,7 +289,7 @@ class Process:
         if ( Process.lastProcess is not None ) :
             Process.lastProcess.libraries.append( lib )
         else :
-            print( "[ Process.addLibrary ]: No Process object defined yet!" )
+            print( "[ Process.addLibrary ]: No Process object defined yet! You need to create a Process before creating any EventProcessors." )
             sys.exit(1)
 
     def skimDefaultIsSave(self):

--- a/python/ldmxcfg.py
+++ b/python/ldmxcfg.py
@@ -16,6 +16,8 @@ class EventProcessor:
         Name of this copy of the producer object
     className : str
         Name (including namespace) of the C++ class that this processor should be
+    libraryName : str
+        Name of module the C++ class is in (e.g. Ecal or SimCore)
 
     Attributes
     ----------
@@ -29,10 +31,12 @@ class EventProcessor:
     LDMX.Framework.histogram.histogram : histogram configuration object
     """
 
-    def __init__(self, instanceName, className):
+    def __init__(self, instanceName, className, moduleName):
         self.instanceName=instanceName
         self.className=className
         self.histograms=[]
+
+        Process.lastProcess.addLibrary( '${CMAKE_INSTALL_PREFIX}/lib/lib%s.so'%moduleName )
 
     def build1DHistogram(self, name, xlabel, bins, xmin = None, xmax = None):
         """Make a 1D histogram 

--- a/python/ldmxcfg.py
+++ b/python/ldmxcfg.py
@@ -16,7 +16,7 @@ class EventProcessor:
         Name of this copy of the producer object
     className : str
         Name (including namespace) of the C++ class that this processor should be
-    libraryName : str
+    moduleName : str
         Name of module the C++ class is in (e.g. Ecal or SimCore)
 
     Attributes
@@ -36,7 +36,7 @@ class EventProcessor:
         self.className=className
         self.histograms=[]
 
-        Process.addLibrary( '${CMAKE_INSTALL_PREFIX}/lib/lib%s.so'%moduleName )
+        Process.addLibrary( '@CMAKE_INSTALL_PREFIX@/lib/lib%s.so'%moduleName )
 
     def build1DHistogram(self, name, xlabel, bins, xmin = None, xmax = None):
         """Make a 1D histogram 

--- a/test/ConfigurePythonTest.cxx
+++ b/test/ConfigurePythonTest.cxx
@@ -113,7 +113,7 @@ TEST_CASE( "Configure Python Test" , "[Framework][functionality]" ) {
 
     testPyScript << "class TestProcessor(ldmxcfg.Producer):" << std::endl;
     testPyScript << "    def __init__(self):" << std::endl;
-    testPyScript << "        super().__init__( 'testInstance' , 'ldmx::test::TestConfig' )" << std::endl;
+    testPyScript << "        super().__init__( 'testInstance' , 'ldmx::test::TestConfig' , 'Framework' )" << std::endl;
     testPyScript << "        self.testInt = 9" << std::endl;
     testPyScript << "        self.testDouble = 7.7" << std::endl;
     testPyScript << "        self.testString = 'Yay!'" << std::endl;


### PR DESCRIPTION
Now we load the module library by passing the module name to the EventProcessor constructor.