### PR TITLE
better extraction procedure for python parameters

### DIFF
--- a/python/ldmxcfg.py
+++ b/python/ldmxcfg.py
@@ -468,7 +468,7 @@ class Process:
 
             if isinstance(obj,list) :
                 return [ extract(o) for o in obj ]
-            elif isinstance(obj,(Process,EventProcessor,simcfg.PrimaryGenerator,simcfg.UserAction,ConditionsObjectProvider)) :
+            elif hasattr(obj,'__dict__') :
                 params = dict()
                 for k in obj.__dict__ :
                     if k not in keys_to_skip :


### PR DESCRIPTION
This allows for any python class that has a `__dict__` member to be extracted, so we don't have to list all the base python classes that we define in any of our modules.