### PR TITLE
Iss909 - Restrict ConditionsObjectProviders to one object to provide

### DIFF
--- a/include/Framework/Conditions.h
+++ b/include/Framework/Conditions.h
@@ -29,88 +29,92 @@
 
 namespace ldmx {
 
-    class Process;
-    class ConditionsObjectProvider;
-    class ConditionsObject;
+class Process;
+class ConditionsObjectProvider;
+class ConditionsObject;
 
-    /**
-     * @class Conditions
-     * @brief Container and cache for conditions and conditions providers
-     */
-    class Conditions {
+/**
+ * @class Conditions
+ * @brief Container and cache for conditions and conditions providers
+ */
+class Conditions {
 
-        public:
+ public:
 
-            /**
-             * Constructor
-             */
-            Conditions(Process&);
+  /**
+   * Constructor
+   */
+  Conditions(Process&);
 
-            /**
-             * Class destructor.
-             */
-            ~Conditions() {;}
-
-            /**
-             * Primary request action for a conditions object If the
-             * object is in the cache and still valid (IOV), the
-             * cached object will be returned.  If it is not in the cache, 
-             * or is out of date, the () method will be called to provide the 
-             * object.
-             */
-            template <class T>
-            const T& getCondition(const std::string& condition_name, const EventHeader& context) {
-                const ConditionsObject* obj=getConditionInternal(condition_name,context);
-                if (!obj) {
-                    EXCEPTION_RAISE("ConditionUnavailableException",
-                            std::string("Requested condition not available for unspecific reason: ")+condition_name);
-                }
-                return dynamic_cast<const T&>(*obj);
-            }
-
-            /**
-             * Calls onProcessStart for all ConditionsObjectProviders
-             */
-            void onProcessStart();
-
-            /**
-             * Calls onProcessEnd for all ConditionsObjectProviders
-             */
-            void onProcessEnd();
+  /**
+   * Class destructor.
+   */
+  ~Conditions() {;}
 
 
-            /** 
-             * Create a ConditionsObjectProvider given the information
-             */
-            void createConditionsObjectProvider(const std::string& classname, const std::string& instancename, const std::string& tagname, const Parameters& params);
+  /**
+   * Primary request action for a conditions object If the
+   * object is in the cache and still valid (IOV), the
+   * cached object will be returned.  If it is not in the cache, 
+   * or is out of date, the () method will be called to provide the 
+   * object.
+   */
+  const ConditionsObject* getConditionPtr(const std::string& condition_name);
+      
+  /**
+   * Primary request action for a conditions object If the
+   * object is in the cache and still valid (IOV), the
+   * cached object will be returned.  If it is not in the cache, 
+   * or is out of date, the () method will be called to provide the 
+   * object.
+   */
+  template <class T>
+  const T& getCondition(const std::string& condition_name) {
+    return dynamic_cast<const T&>(*getConditionPtr(condition_name));    
+  }
+
+  /**
+   * Access the IOV for the given condition
+   */
+  ConditionsIOV getConditionIOV(const std::string& condition_name) const;
+
+  /**
+   * Calls onProcessStart for all ConditionsObjectProviders
+   */
+  void onProcessStart();
+
+  /**
+   * Calls onProcessEnd for all ConditionsObjectProviders
+   */
+  void onProcessEnd();
+
+
+  /** 
+   * Create a ConditionsObjectProvider given the information
+   */
+  void createConditionsObjectProvider(const std::string& classname, const std::string& instancename, const std::string& tagname, const Parameters& params);
         
-       private:
+ private:
 
-            /** Cache-managing method */
-            const ConditionsObject* getConditionInternal(const std::string& condition_name, const EventHeader& context);
-        
-            /** Handle to the Process. */
-            Process& process_;
+  /** Handle to the Process. */
+  Process& process_;
 
-            /** Set of conditions object providers */
-            std::vector<ConditionsObjectProvider*> providers_;
+  /** Map of who provides which condition */
+  std::map<std::string, ConditionsObjectProvider*> providerMap_;
     
-            /** Map of who provides which condition */
-            std::map<std::string, ConditionsObjectProvider*> providerMap_;
+  /**
+   * An entry to store an already loaded conditions object
+   */
+  struct CacheEntry {
+    ConditionsIOV iov;
+    ConditionsObjectProvider* provider;
+    const ConditionsObject* obj;
+  };
     
-            /**
-             * An entry to store an already loaded conditions object
-             */
-            struct CacheEntry {
-                ConditionsIOV iov;
-                ConditionsObjectProvider* provider;
-                const ConditionsObject* obj;
-            };
-    
-            /** Conditions cache */
-            std::map<std::string,CacheEntry> cache_;
-    };
+  /** Conditions cache */
+  std::map<std::string,CacheEntry> cache_;
+};
 
-}
+} // namespace ldmx
 
 #endif

--- a/include/Framework/ConditionsObject.h
+++ b/include/Framework/ConditionsObject.h
@@ -10,33 +10,34 @@
 
 namespace ldmx {
 
-   /**
-    * @class ConditionsObject
-    * @brief Base class for all conditions objects, very simple
-    */
-  class ConditionsObject {
-        public:
-            /**
-             * Class constructor
-             */
-            ConditionsObject(const std::string& name) : name_(name) { }
+/**
+ * @class ConditionsObject
+ * @brief Base class for all conditions objects, very simple
+ */
+class ConditionsObject {
+ public:
+  /**
+   * Class constructor
+   */
+  ConditionsObject(const std::string& name) : name_(name) { }
         
-            /**
-             * Destructor
-             */
-            virtual ~ConditionsObject() { }
+  /**
+   * Destructor
+   */
+  virtual ~ConditionsObject() { }
         
-            /**
-             * Get the name of this object
-             */
-            std::string getName() const { return name_; }
+  /**
+   * Get the name of this object
+   */
+  std::string getName() const { return name_; }
         
-        private:
-            /** 
-             * Name of the object
-             */
-            std::string name_;
-    };
-}
+ private:
+  /** 
+   * Name of the object
+   */
+  std::string name_;
+};
+
+} // namespace ldmx
 
 #endif

--- a/include/Framework/ConditionsObjectProvider.h
+++ b/include/Framework/ConditionsObjectProvider.h
@@ -27,110 +27,109 @@
 
 namespace ldmx {
 
-    class Process;
-    class ConditionsObjectProvider;
-    class EventHeader;
+class Process;
+class ConditionsObjectProvider;
+class EventHeader;
 
-    /** Typedef for PluginFactory use. */
-    typedef ConditionsObjectProvider* 
-        ConditionsObjectProviderMaker(const std::string& name, const std::string& tagname, const Parameters& params, Process& process);
+/** Typedef for PluginFactory use. */
+typedef ConditionsObjectProvider* 
+ConditionsObjectProviderMaker(const std::string& objname, const std::string& tagname, const Parameters& params, Process& process);
 
-    /**
-     * @class ConditionsObjectProvider
-     * @brief Base class for all providers of conditions objects
-     */
-    class ConditionsObjectProvider {
+/**
+ * @class ConditionsObjectProvider
+ * @brief Base class for all providers of conditions objects
+ */
+class ConditionsObjectProvider {
 
-        public:
+ public:
 
-            /** Constant used to types by the PluginFactory */
-            static const int CLASSTYPE{10};
+  /** Constant used to types by the PluginFactory */
+  static const int CLASSTYPE{10};
         
-            /**
-             * Class constructor.
-             * @param name Name for this instance of the class.
-             * @param tagName The tag for the database entry (should not include whitespace)
-             * @param process The Process class associated with ConditionsObjectProvider, provided by the framework.
-             *
-             * @note The name provided to this function should not be
-             * the class name, but rather a logical label for this instance of
-             * the class, as more than one copy of a given class can be loaded
-             * into a Process with different parameters.  Names should not include
-             * whitespace or special characters.
-             */
-            ConditionsObjectProvider(const std::string& name, const std::string& tagname, const Parameters& parameters, Process& process);
+  /**
+   * Class constructor.
+   * @param name Name for this instance of the class.
+   * @param tagName The tag for the database entry (should not include whitespace)
+   * @param process The Process class associated with ConditionsObjectProvider, provided by the framework.
+   *
+   * @note The name provided to this function should not be
+   * the class name, but rather a logical label for this instance of
+   * the class, as more than one copy of a given class can be loaded
+   * into a Process with different parameters.  Names should not include
+   * whitespace or special characters.
+   */
+  ConditionsObjectProvider(const std::string& objname, const std::string& tagname, const Parameters& parameters, Process& process);
 
-            /**
-             * Class destructor.
-             */
-            virtual ~ConditionsObjectProvider() {;}
+  /**
+   * Class destructor.
+   */
+  virtual ~ConditionsObjectProvider() {;}
 
-            /**
-             * Pure virtual getCondition function.
-             * Must be implemented by any Conditions providers.
-             */
-            virtual std::pair<const ConditionsObject*,ConditionsIOV> getCondition(const std::string& condition_name, const EventHeader& context) = 0;
+  /**
+   * Pure virtual getCondition function.
+   * Must be implemented by any Conditions providers.
+   */
+  virtual std::pair<const ConditionsObject*,ConditionsIOV> getCondition(const EventHeader& context) = 0;
 
-            /**
-             * Called by conditions system when done with a conditions object, appropriate point for cleanup.
-             * @note Default behavior is to delete the object!
-             */
-            virtual void releaseConditionsObject(const ConditionsObject* co) {
-                delete co;
-            }
+  /**
+   * Called by conditions system when done with a conditions object, appropriate point for cleanup.
+   * @note Default behavior is to delete the object!
+   */
+  virtual void releaseConditionsObject(const ConditionsObject* co) {
+    delete co;
+  }
     
-            /**
-             * Callback for the ConditionsObjectProvider to take any necessary
-             * action when the processing of events starts.
-             */
-            virtual void onProcessStart() {
-            }
+  /**
+   * Callback for the ConditionsObjectProvider to take any necessary
+   * action when the processing of events starts.
+   */
+  virtual void onProcessStart() {
+  }
 
-            /**
-             * Callback for the ConditionsObjectProvider to take any necessary
-             * action when the processing of events finishes, such as closing
-             * database connections.
-             */
-            virtual void onProcessEnd() {
-            }
+  /**
+   * Callback for the ConditionsObjectProvider to take any necessary
+   * action when the processing of events finishes, such as closing
+   * database connections.
+   */
+  virtual void onProcessEnd() {
+  }
 
-            /**
-             * Get the list of conditions objects available from this provider.
-             */
-            const std::vector<std::string>& getConditionObjectsAvailable() const { return objectNames_; }
+  /**
+   * Get the list of conditions objects available from this provider.
+   */
+  const std::string& getConditionObjectName() const { return objectName_; }
         
-            /**
-             * Internal function which is part of the PluginFactory machinery.
-             * @param classname The class name of the processor.
-             */
-            static void declare(const std::string& classname, ConditionsObjectProviderMaker*);
+  /**
+   * Internal function which is part of the PluginFactory machinery.
+   * @param classname The class name of the processor.
+   */
+  static void declare(const std::string& classname, ConditionsObjectProviderMaker*);
 
-            /** 
-             * Access the tag name
-             */
-            const std::string& getTagName() const { return tagname_; }
+  /** 
+   * Access the tag name
+   */
+  const std::string& getTagName() const { return tagname_; }
     
-        protected:
+ protected:
 
-            /// The logger for this ConditionsObjectProvider
-            logging::logger theLog_;
+  /** Request another condition needed to construct this condition */
+  std::pair<const ConditionsObject*,ConditionsIOV> requestParentCondition(const std::string& name, const EventHeader& context);
+  
+  /// The logger for this ConditionsObjectProvider
+  logging::logger theLog_;
 
-            /** The list of conditions objects available from this provider, should be filled by derived classes */
-            std::vector<std::string> objectNames_;          
-    
-       private:
+ private:
 
-            /** Handle to the Process. */
-            Process& process_;
+  /** Handle to the Process. */
+  Process& process_;
 
-            /** The name of the ConditionsObjectProvider. */
-            std::string name_;
+  /** The name of the object provided by this provider. */
+  std::string objectName_;
 
-            /** The tag name for the ConditionsObjectProvider. */
-            std::string tagname_;
+  /** The tag name for the ConditionsObjectProvider. */
+  std::string tagname_;
 
-
-    };
+};
 
 }
 

--- a/include/Framework/Parameters.h
+++ b/include/Framework/Parameters.h
@@ -103,7 +103,7 @@ namespace ldmx {
                     parameter = std::any_cast< T >(parameters_.at(name));
                 } catch(const std::bad_any_cast& e) {
                     EXCEPTION_RAISE( "BadTypeParam",
-                                    "Parameter '" + name + "' is being cast to incorrect type '" + typeid(T).name() + "'."); 
+                                     "Parameter '" + name + "' of type '"+parameters_.at(name).type().name()+"' is being cast to incorrect type '" + typeid(T).name() + "'."); 
                 }
 
                 return parameter; 

--- a/include/Framework/PluginFactory.h
+++ b/include/Framework/PluginFactory.h
@@ -18,101 +18,101 @@
 
 namespace ldmx {
 
-    /**
-     * @class PluginFactory
-     * @brief Singleton module factory that creates EventProcessor objects.
-     */
-    class PluginFactory {
+/**
+ * @class PluginFactory
+ * @brief Singleton module factory that creates EventProcessor objects.
+ */
+class PluginFactory {
 
-        public:
+ public:
 
-            /**
-             * Get the factory instance.
-             * @return The factory.
-             */
-            static PluginFactory& getInstance() {
-                return theFactory_;
-            }
+  /**
+   * Get the factory instance.
+   * @return The factory.
+   */
+  static PluginFactory& getInstance() {
+    return theFactory_;
+  }
 
-            /**
-             * Register the event processor.
-             * @param classname The name of the class associated with processor.
-             * @param classtype The type of class associated with processor.
-             * @param maker TODO.
-             */
-            void registerEventProcessor(const std::string& classname, int classtype, EventProcessorMaker* maker);
+  /**
+   * Register the event processor.
+   * @param classname The name of the class associated with processor.
+   * @param classtype The type of class associated with processor.
+   * @param maker TODO.
+   */
+  void registerEventProcessor(const std::string& classname, int classtype, EventProcessorMaker* maker);
 
-            /**
-             * Register a conditions object provider
-             * @param classname The name of the class associated with the conditions object provider.
-             * @param classtype The type of class associated with conditions object provider.
-             * @param maker TODO.
-             */
-            void registerConditionsObjectProvider(const std::string& classname, int classtype, ConditionsObjectProviderMaker* maker);
+  /**
+   * Register a conditions object provider
+   * @param classname The name of the class associated with the conditions object provider.
+   * @param classtype The type of class associated with conditions object provider.
+   * @param maker TODO.
+   */
+  void registerConditionsObjectProvider(const std::string& classname, int classtype, ConditionsObjectProviderMaker* maker);
       
-            /**
-             * Get the classes associated with the processor.
-             * @return a vector of strings corresponding to processor classes.
-             */
-            std::vector<std::string> getEventProcessorClasses() const;
+  /**
+   * Get the classes associated with the processor.
+   * @return a vector of strings corresponding to processor classes.
+   */
+  std::vector<std::string> getEventProcessorClasses() const;
 
-            /**
-             * Get the class type for the event processor.
-             * @param TODO.
-             */
-            int getEventProcessorClasstype(const std::string&) const;
+  /**
+   * Get the class type for the event processor.
+   * @param TODO.
+   */
+  int getEventProcessorClasstype(const std::string&) const;
 
-            /**
-             * Make an event processor.
-             * @param classname Class name of event processor.
-             * @param moduleInstanceName TODO.
-             * @param process The process handle
-             */
-            EventProcessor* createEventProcessor(const std::string& classname, const std::string& moduleInstanceName, Process& process);
+  /**
+   * Make an event processor.
+   * @param classname Class name of event processor.
+   * @param moduleInstanceName TODO.
+   * @param process The process handle
+   */
+  EventProcessor* createEventProcessor(const std::string& classname, const std::string& moduleInstanceName, Process& process);
 
-            /**
-             * Make a conditions object provider
-             * @param classname Class name of conditions object provider
-             * @param moduleInstanceName 
-             * @param params Parameters for the conditoons object provider
-             * @param process The process handle
-             */
-            ConditionsObjectProvider* createConditionsObjectProvider(const std::string& classname, const std::string& moduleInstanceName, const std::string& tagname, const Parameters& params, Process& process);
+  /**
+   * Make a conditions object provider
+   * @param classname Class name of conditions object provider
+   * @param objName Name of the object provided (may be overriden internally!)
+   * @param params Parameters for the conditoons object provider
+   * @param process The process handle
+   */
+  ConditionsObjectProvider* createConditionsObjectProvider(const std::string& classname, const std::string& objName, const std::string& tagname, const Parameters& params, Process& process);
 
-            /**
-             * Load a library.
-             * @param libname The library to load.
-             */
-            void loadLibrary(const std::string& libname);
+  /**
+   * Load a library.
+   * @param libname The library to load.
+   */
+  void loadLibrary(const std::string& libname);
 
-        private:
+ private:
 
-            /**
-             * Constructor
-             */
-            PluginFactory();
+  /**
+   * Constructor
+   */
+  PluginFactory();
 
-            /**
-             * @struct PluginInfo
-             * @brief info container to hold classname, class type and maker.
-             */
-            struct PluginInfo {
-                std::string classname;
-                int classtype;
-                EventProcessorMaker* ep_maker;
-                ConditionsObjectProviderMaker* cop_maker;
-            };
+  /**
+   * @struct PluginInfo
+   * @brief info container to hold classname, class type and maker.
+   */
+  struct PluginInfo {
+    std::string classname;
+    int classtype;
+    EventProcessorMaker* ep_maker;
+    ConditionsObjectProviderMaker* cop_maker;
+  };
 
-            /** A map of names to processor containers. */
-            std::map<std::string, PluginInfo> moduleInfo_;
+  /** A map of names to processor containers. */
+  std::map<std::string, PluginInfo> moduleInfo_;
 
-            /** A set of names of loaded libraries. */
-            std::set<std::string> librariesLoaded_;
+  /** A set of names of loaded libraries. */
+  std::set<std::string> librariesLoaded_;
 
-            /** Factory for creating the plugin objects. */
-            static PluginFactory theFactory_;
-    };
+  /** Factory for creating the plugin objects. */
+  static PluginFactory theFactory_;
+};
 
-}
+} // namespace ldmx
 
 #endif

--- a/include/Framework/Process.h
+++ b/include/Framework/Process.h
@@ -105,6 +105,12 @@ namespace ldmx {
             StorageControl& getStorageController() { return m_storageController; }
 
             /**
+             * Set the pointer to the current event header, used only for tests
+             */
+            void setEventHeader(EventHeader* h) { eventHeader_=h; }
+
+
+      /**
              * Get a dummy process
              *
              * This function returns an instance of this class without

--- a/python/ldmxcfg.py
+++ b/python/ldmxcfg.py
@@ -237,7 +237,7 @@ class ConditionsObjectProvider:
         if not isinstance(ConditionsObjectProvider,other) :
             return NotImplemented
 
-        return (self.instanceName == other.instanceName and self.className == other.className)
+        return (self.objectName == other.objectName and self.className == other.className)
 
     def __str__(self) :
         """Stringify this ConditionsObjectProvider, creates a message with all the internal parameters.

--- a/python/ldmxcfg.py
+++ b/python/ldmxcfg.py
@@ -196,21 +196,48 @@ class ConditionsObjectProvider:
 
     This object contains the parameters that are necessary for a ldmx::ConditionsObjectProvider to be configured.
 
+    In this constructor we also do two helpful processes.
+    1. We append the module that this provider is in to the list of libraries to load
+    2. We declare this provider so that the Process "knows" it exists and will load it into the run
+
     Parameters
     ----------
-    instanceName : str
-        Name of this copy of the provider object
+    objectName : str
+        Name of the object this provider provides
     className : str
         Name (including namespace) of the C++ class of the provider
     tagName : str
         Tag which identifies the generation of information
-
+    moduleName : str
+        Name of module that this COP is compiled into (e.g. Ecal or EventProc)
     """
 
-    def __init__(self, instanceName, className, tagName):
-        self.instanceName=instanceName
+    def __init__(self, objectName, className, tagName, moduleName):
+        self.objectName=objectName
         self.className=className
         self.tagName=tagName
+
+        # make sure process loads this library if it hasn't yet
+        Process.addLibrary( '@CMAKE_INSTALL_PREFIX@/lib/lib%s.so'%moduleName )
+        
+        #register this conditions object provider with the process
+        Process.declareConditionsObjectProvider(self)
+
+    def __eq__(self,other) :
+        """Check if two COPs are the same
+
+        We decide that two COPs are 'equal' if they have the same instance and class names
+        
+        Parameters
+        ----------
+        other : ConditionsObjectProvider
+            other COP to compare agains
+        """
+
+        if not isinstance(ConditionsObjectProvider,other) :
+            return NotImplemented
+
+        return (self.instanceName == other.instanceName and self.className == other.className)
 
     def __str__(self) :
         """Stringify this ConditionsObjectProvider, creates a message with all the internal parameters.
@@ -289,6 +316,10 @@ class Process:
     lastProcess=None
     
     def __init__(self, passName):
+
+        if ( Process.lastProcess is not None ) :
+            raise Exception( "Process object is already created! You can only create one Process object in a script." )
+
         self.passName=passName
         self.maxEvents=-1
         self.maxTriesPerEvent=1
@@ -331,12 +362,36 @@ class Process:
         if ( Process.lastProcess is not None ) :
             Process.lastProcess.libraries.append( lib )
         else :
-            print( "[ Process.addLibrary ]: No Process object defined yet! You need to create a Process before creating any EventProcessors." )
-            sys.exit(1)
+            raise Exception( "No Process object defined yet! You need to create a Process before creating any EventProcessors." )
 
-    def declareConditionsObjectProvider(self, cop):
-        """Add a new conditions object provider to the list"""
-        self.conditionsObjectProviders.append( cop )
+    def declareConditionsObjectProvider(cop):
+        """Declare a conditions object provider to be loaded with the process
+
+        A process object must already have been created.
+
+        Parameters
+        ----------
+        cop : ConditionsObjectProvider
+            provider to load with the process
+
+        Warnings
+        --------
+        - Will exit the script if a process object hasn't been defined yet.
+        - Overrides an already declared COP with the passed COP if they are equal
+        """
+
+        if ( Process.lastProcess is not None ) :
+
+            # check if the input COP matches one already declared
+            #   if it does match, override the already declared one with the passed one
+            for index, already_defined_cop in enumerate(Process.lastProcess.conditionsObjectProviders) :
+                if cop == already_defined_cop :
+                    Process.lastProcess.conditionsObjectProviders[index] = cop
+                    return
+
+            Process.lastProcess.conditionsObjectProviders.append( cop )
+        else :
+            raise Exception( "No Process object defined yet! You need to create a Process before declaring any ConditionsObjectProviders." )
             
     def skimDefaultIsSave(self):
         """Configure the process to by default keep every event."""

--- a/src/Conditions.cxx
+++ b/src/Conditions.cxx
@@ -1,85 +1,94 @@
 #include "Framework/Conditions.h"
 #include "Framework/PluginFactory.h"
+#include "Framework/Process.h"
 #include <sstream>
 
 namespace ldmx {
 
-    Conditions::Conditions(Process& p) : process_{p} {
-    }
-    
-    void Conditions::createConditionsObjectProvider(const std::string& classname, const std::string& instancename, const std::string& tagname, const Parameters& params) {
-        ConditionsObjectProvider* cop = 
-            PluginFactory::getInstance().createConditionsObjectProvider(classname,instancename,tagname,params,process_);
-        if (cop) {
-            providers_.push_back(cop);
-    
-            std::vector<std::string> provides=cop->getConditionObjectsAvailable();
-            for (auto sptr : provides) {
-                if (providerMap_.find(sptr)!=providerMap_.end()) {
-                    EXCEPTION_RAISE("ConditionAmbiguityException",
-                            std::string("Multiple ConditonsObjectProviders configured to provide ")+sptr);
-                }
-                providerMap_[sptr]=cop;
-            }
-        } else {
-          EXCEPTION_RAISE("ConditionsException","No ConditionsObjectProvider for "+classname);    
-        }
-    }
-
-    void Conditions::onProcessStart() {
-        for (auto ptr: providers_)
-            ptr->onProcessStart();
-    }
-    
-    void Conditions::onProcessEnd() {
-        for (auto ptr: providers_)
-            ptr->onProcessEnd();
-    }
-
-
-    const ConditionsObject* Conditions::getConditionInternal(const std::string& condition_name, const EventHeader& context) {
-        auto cacheptr = cache_.find(condition_name);
-        
-        if (cacheptr == cache_.end()) {
-            auto copptr = providerMap_.find(condition_name);
-            
-            if (copptr==providerMap_.end()) {
-                EXCEPTION_RAISE("ConditionUnavailable",std::string("No provider is available for : "+condition_name));
-            }
-            
-            std::pair<const ConditionsObject*,ConditionsIOV> cond=copptr->second->getCondition(condition_name,context);
-            
-            if (!cond.first) {
-                EXCEPTION_RAISE("ConditionUnavailable",std::string("Null condition returned for requested item : "+condition_name));
-            }
-            // first request, create a cache entry
-            CacheEntry ce;
-            ce.iov=cond.second;
-            ce.obj=cond.first;
-            ce.provider=copptr->second;
-            cache_[condition_name]=ce;
-        } else {
-            /// if still valid, we return what we have
-            if (cacheptr->second.iov.validForEvent(context)) return cacheptr->second.obj;
-            else {
-                // if not, we release the old object
-                cacheptr->second.provider->releaseConditionsObject(cacheptr->second.obj);
-                // now ask for a new one
-                std::pair<const ConditionsObject*,ConditionsIOV> cond=cacheptr->second.provider->getCondition(condition_name,context);
-                
-                if (!cond.first) {
-                    std::stringstream s;
-                    s << "Unable to update condition '" 
-                      << condition_name << "' for event " 
-                      << context.getEventNumber() << " run " << context.getRun();
-                    if (context.isRealData()) s << " DATA";
-                    else s << " MC";
-                    EXCEPTION_RAISE("ConditionUnavailable",s.str());
-                }
-                cacheptr->second.iov=cond.second;
-                cacheptr->second.obj=cond.first;
-                return cond.first;
-            }
-        }
-    }   
+Conditions::Conditions(Process& p) : process_{p} {
 }
+    
+void Conditions::createConditionsObjectProvider(const std::string& classname, const std::string& objname, const std::string& tagname, const Parameters& params) {
+  ConditionsObjectProvider* cop = 
+      PluginFactory::getInstance().createConditionsObjectProvider(classname,objname,tagname,params,process_);
+
+  if (cop) {
+    std::string provides=cop->getConditionObjectName();    
+    if (providerMap_.find(provides)!=providerMap_.end()) {
+      EXCEPTION_RAISE("ConditionAmbiguityException",
+                      std::string("Multiple ConditonsObjectProviders configured to provide ")+provides);
+    }
+    providerMap_[provides]=cop;
+  } else {
+    EXCEPTION_RAISE("ConditionsException","No ConditionsObjectProvider for "+classname);    
+  }
+}
+
+void Conditions::onProcessStart() {
+  for (auto ptr: providerMap_)
+    ptr.second->onProcessStart();
+}
+
+void Conditions::onProcessEnd() {
+  for (auto ptr: providerMap_)
+    ptr.second->onProcessEnd();
+}
+
+ConditionsIOV Conditions::getConditionIOV(const std::string& condition_name) const {
+  
+  auto cacheptr = cache_.find(condition_name);
+  if (cacheptr == cache_.end()) return ConditionsIOV();
+  else return cacheptr->second.iov;
+}
+ 
+const ConditionsObject* Conditions::getConditionPtr(const std::string& condition_name) {
+  
+  const EventHeader& context=*(process_.getEventHeader());
+  auto cacheptr = cache_.find(condition_name);
+        
+  if (cacheptr == cache_.end()) {
+    auto copptr = providerMap_.find(condition_name);
+            
+    if (copptr==providerMap_.end()) {
+      EXCEPTION_RAISE("ConditionUnavailable",std::string("No provider is available for : "+condition_name));
+    }
+            
+    std::pair<const ConditionsObject*,ConditionsIOV> cond=copptr->second->getCondition(context);
+            
+    if (!cond.first) {
+      EXCEPTION_RAISE("ConditionUnavailable",std::string("Null condition returned for requested item : "+condition_name));
+    }
+
+    // first request, create a cache entry
+    CacheEntry ce;
+    ce.iov=cond.second;
+    ce.obj=cond.first;
+    ce.provider=copptr->second;
+    cache_[condition_name]=ce;
+    return ce.obj;
+  } else {
+    /// if still valid, we return what we have
+    if (cacheptr->second.iov.validForEvent(context)) return cacheptr->second.obj;
+    else {
+      // if not, we release the old object
+      cacheptr->second.provider->releaseConditionsObject(cacheptr->second.obj);
+      // now ask for a new one
+      std::pair<const ConditionsObject*,ConditionsIOV> cond=cacheptr->second.provider->getCondition(context);
+      
+      if (!cond.first) {
+        std::stringstream s;
+        s << "Unable to update condition '" 
+          << condition_name << "' for event " 
+          << context.getEventNumber() << " run " << context.getRun();
+        if (context.isRealData()) s << " DATA";
+        else s << " MC";
+        EXCEPTION_RAISE("ConditionUnavailable",s.str());
+      }
+      cacheptr->second.iov=cond.second;
+      cacheptr->second.obj=cond.first;
+      return cond.first;
+    }
+  }
+}
+
+} // namespace ldmx

--- a/src/ConditionsObjectProvider.cxx
+++ b/src/ConditionsObjectProvider.cxx
@@ -6,11 +6,19 @@
 
 namespace ldmx {
     
-    ConditionsObjectProvider::ConditionsObjectProvider(const std::string& name, const std::string& tagname, const Parameters& params, Process& process) :
-        process_{process}, name_ {name}, tagname_{tagname}, theLog_{logging::makeLogger(name)} { }
-    
-    void ConditionsObjectProvider::declare(const std::string& classname, ConditionsObjectProviderMaker* maker) {
-        PluginFactory::getInstance().registerConditionsObjectProvider(classname, CLASSTYPE, maker);
-    }
+ConditionsObjectProvider::ConditionsObjectProvider(const std::string& objname, const std::string& tagname, const Parameters& params, Process& process) :
+    process_{process}, objectName_ {objname}, tagname_{tagname}, theLog_{logging::makeLogger(objname)} { }
+
+
+std::pair<const ConditionsObject*,ConditionsIOV> ConditionsObjectProvider::requestParentCondition(const std::string& name, const EventHeader& context) {
+  const ConditionsObject* obj=process_.getConditions().getConditionPtr(name);
+  ConditionsIOV iov=process_.getConditions().getConditionIOV(name);
+  return std::make_pair(obj,iov);
+}
+
+
+void ConditionsObjectProvider::declare(const std::string& classname, ConditionsObjectProviderMaker* maker) {
+  PluginFactory::getInstance().registerConditionsObjectProvider(classname, CLASSTYPE, maker);
+}
 
 }

--- a/src/PluginFactory.cxx
+++ b/src/PluginFactory.cxx
@@ -6,81 +6,81 @@ ldmx::PluginFactory ldmx::PluginFactory::theFactory_ __attribute((init_priority(
 
 namespace ldmx {
 
-    PluginFactory::PluginFactory() {
-    }
+PluginFactory::PluginFactory() {
+}
     
-    void PluginFactory::registerEventProcessor(const std::string& classname, int classtype, EventProcessorMaker* maker) {
-        auto ptr = moduleInfo_.find(classname);
-        if (ptr != moduleInfo_.end()) {
-            EXCEPTION_RAISE("ExistingEventProcessorDefinition", "Already have a module registered with the classname '" + classname + "'");
-        }
-        PluginInfo mi;
-        mi.classname = classname;
-        mi.classtype = classtype;
-        mi.ep_maker = maker;
-        mi.cop_maker = 0;
-        moduleInfo_[classname] = mi;
-    }
+void PluginFactory::registerEventProcessor(const std::string& classname, int classtype, EventProcessorMaker* maker) {
+  auto ptr = moduleInfo_.find(classname);
+  if (ptr != moduleInfo_.end()) {
+    EXCEPTION_RAISE("ExistingEventProcessorDefinition", "Already have a module registered with the classname '" + classname + "'");
+  }
+  PluginInfo mi;
+  mi.classname = classname;
+  mi.classtype = classtype;
+  mi.ep_maker = maker;
+  mi.cop_maker = 0;
+  moduleInfo_[classname] = mi;
+}
     
-    void PluginFactory::registerConditionsObjectProvider(const std::string& classname, int classtype, ConditionsObjectProviderMaker* maker) {
-        auto ptr = moduleInfo_.find(classname);
-        if (ptr != moduleInfo_.end()) {
-            EXCEPTION_RAISE("ExistingEventProcessorDefinition", "Already have a module registered with the classname '" + classname + "'");
-        }
-        PluginInfo mi;
-        mi.classname = classname;
-        mi.classtype = classtype;
-        mi.cop_maker = maker;
-        mi.ep_maker = 0;
-        moduleInfo_[classname] = mi;
-    }
+void PluginFactory::registerConditionsObjectProvider(const std::string& classname, int classtype, ConditionsObjectProviderMaker* maker) {
+  auto ptr = moduleInfo_.find(classname);
+  if (ptr != moduleInfo_.end()) {
+    EXCEPTION_RAISE("ExistingEventProcessorDefinition", "Already have a module registered with the classname '" + classname + "'");
+  }
+  PluginInfo mi;
+  mi.classname = classname;
+  mi.classtype = classtype;
+  mi.cop_maker = maker;
+  mi.ep_maker = 0;
+  moduleInfo_[classname] = mi;
+}
 
-    std::vector<std::string> PluginFactory::getEventProcessorClasses() const {
-        std::vector<std::string> classes;
-        for (auto ptr : moduleInfo_) {
-        if (ptr.second.ep_maker!=0)
-        classes.push_back(ptr.first);
-        }
-        return classes;
-    }
+std::vector<std::string> PluginFactory::getEventProcessorClasses() const {
+  std::vector<std::string> classes;
+  for (auto ptr : moduleInfo_) {
+    if (ptr.second.ep_maker!=0)
+      classes.push_back(ptr.first);
+  }
+  return classes;
+}
 
-    int PluginFactory::getEventProcessorClasstype(const std::string& ct) const {
-        auto ptr = moduleInfo_.find(ct);
-        if (ptr == moduleInfo_.end() || ptr->second.ep_maker==0) {
-            return 0;
+int PluginFactory::getEventProcessorClasstype(const std::string& ct) const {
+  auto ptr = moduleInfo_.find(ct);
+  if (ptr == moduleInfo_.end() || ptr->second.ep_maker==0) {
+    return 0;
 
-        } else {
-            return ptr->second.classtype;
-        }
-    }
+  } else {
+    return ptr->second.classtype;
+  }
+}
 
-    EventProcessor* PluginFactory::createEventProcessor(const std::string& classname, const std::string& moduleInstanceName, Process& process) {
-        auto ptr = moduleInfo_.find(classname);
-        if (ptr == moduleInfo_.end() || ptr->second.ep_maker==0) {
-            return 0;
-        }
-        return ptr->second.ep_maker(moduleInstanceName, process);
-    }
+EventProcessor* PluginFactory::createEventProcessor(const std::string& classname, const std::string& moduleInstanceName, Process& process) {
+  auto ptr = moduleInfo_.find(classname);
+  if (ptr == moduleInfo_.end() || ptr->second.ep_maker==0) {
+    return 0;
+  }
+  return ptr->second.ep_maker(moduleInstanceName, process);
+}
 
-    ConditionsObjectProvider* PluginFactory::createConditionsObjectProvider(const std::string& classname, const std::string& moduleInstanceName, const std::string& tagname, const Parameters& params, Process& process) {
-        auto ptr = moduleInfo_.find(classname);
-        if (ptr == moduleInfo_.end() || ptr->second.cop_maker==0) {
-            return 0;
-        }
-        return ptr->second.cop_maker(moduleInstanceName, tagname, params, process);
-    }
+ConditionsObjectProvider* PluginFactory::createConditionsObjectProvider(const std::string& classname, const std::string& objName, const std::string& tagname, const Parameters& params, Process& process) {
+  auto ptr = moduleInfo_.find(classname);
+  if (ptr == moduleInfo_.end() || ptr->second.cop_maker==0) {
+    return 0;
+  }
+  return ptr->second.cop_maker(objName, tagname, params, process);
+}
 
-    void PluginFactory::loadLibrary(const std::string& libname) {
-        if (librariesLoaded_.find(libname) != librariesLoaded_.end()) {
-            return; // already loaded
-        }
+void PluginFactory::loadLibrary(const std::string& libname) {
+  if (librariesLoaded_.find(libname) != librariesLoaded_.end()) {
+    return; // already loaded
+  }
 
-        void* handle = dlopen(libname.c_str(), RTLD_NOW);
-        if (handle == nullptr) {
-            EXCEPTION_RAISE("LibraryLoadFailure", "Error loading library '" + libname + "':" + dlerror());
-        }
+  void* handle = dlopen(libname.c_str(), RTLD_NOW);
+  if (handle == nullptr) {
+    EXCEPTION_RAISE("LibraryLoadFailure", "Error loading library '" + libname + "':" + dlerror());
+  }
 
-        librariesLoaded_.insert(libname);
-    }
+  librariesLoaded_.insert(libname);
+}
 
 }

--- a/src/Process.cxx
+++ b/src/Process.cxx
@@ -84,10 +84,10 @@ namespace ldmx {
         for (auto cop : conditionsObjectProviders) {
       
             auto className{cop.getParameter<std::string>("className")};
-            auto instanceName{cop.getParameter<std::string>("instanceName")};
+            auto objectName{cop.getParameter<std::string>("objectName")};
             auto tagName{cop.getParameter<std::string>("tagName")};
 
-            conditions_.createConditionsObjectProvider(className, instanceName, tagName, cop);
+            conditions_.createConditionsObjectProvider(className, objectName, tagName, cop);
         }
     }
 


### PR DESCRIPTION
This restriction makes configuring the COPs much easier because they map onto the provided objects one-to-one.