### PR TITLE
Compare Tree Content without Full Constructing Branch Structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,3 +132,7 @@ setup_library(module Framework name TreeDiff
               dependencies Framework::Exception
                            ROOT::Core
                            ROOT::TreePlayer)
+
+add_executable(tree-diff ${PROJECT_SOURCE_DIR}/src/Framework/TreeDiff/tree_diff.cxx)
+target_link_libraries(tree-diff PRIVATE Framework::TreeDiff)
+install(TARGETS tree-diff DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,3 +136,7 @@ setup_library(module Framework name TreeDiff
 add_executable(tree-diff ${PROJECT_SOURCE_DIR}/src/Framework/TreeDiff/tree_diff.cxx)
 target_link_libraries(tree-diff PRIVATE Framework::TreeDiff)
 install(TARGETS tree-diff DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+
+add_executable(test-fire ${PROJECT_SOURCE_DIR}/src/Framework/Testing/test_fire.cxx)
+target_link_libraries(test-fire PRIVATE Framework::TreeDiff Framework::Framework)
+install(TARGETS test-fire DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,3 +127,8 @@ install(TARGETS fire DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 setup_test(dependencies Framework::Framework)
 
 setup_python(package_name ${PYTHON_PACKAGE_NAME}/Framework)
+
+setup_library(module Framework name TreeDiff
+              dependencies Framework::Exception
+                           ROOT::Core
+                           ROOT::TreePlayer)

--- a/include/Framework/TreeDiff/BareBranch.h
+++ b/include/Framework/TreeDiff/BareBranch.h
@@ -1,8 +1,8 @@
 #ifndef FRAMEWORK_TREEDIFF_BAREBRANCH_H
 #define FRAMEWORK_TREEDIFF_BAREBRANCH_H
 
-#include "TFile.h"
 #include "TBranch.h"
+#include "TFile.h"
 
 namespace framework {
 namespace treediff {
@@ -34,15 +34,13 @@ class BareBranch {
    * and the full name will give us the name of
    * the sub branch and all its parent branches.
    */
-  const TString name() const {
-    return branch_->GetFullName();
-  }
+  const TString name() const { return branch_->GetFullName(); }
 
   /**
    * Do we and the passed BareBranch have the same name?
    */
   bool sameName(const BareBranch& other) const {
-    return name().EqualTo(other.name()); 
+    return name().EqualTo(other.name());
   }
 
   /**
@@ -67,7 +65,6 @@ class BareBranch {
   char* getContent(int i_basket, int& len) const;
 
  private:
-
   /**
    * The file that we are reading the data from.
    *
@@ -89,7 +86,7 @@ class BareBranch {
   TBranch* branch_;
 };
 
-}
-}
+}  // namespace treediff
+}  // namespace framework
 
-#endif // FRAMEWORK_TREEDIFF_BAREBRANCH_H
+#endif  // FRAMEWORK_TREEDIFF_BAREBRANCH_H

--- a/include/Framework/TreeDiff/BareBranch.h
+++ b/include/Framework/TreeDiff/BareBranch.h
@@ -42,7 +42,7 @@ class BareBranch {
    * Do we and the passed BareBranch have the same name?
    */
   bool sameName(const BareBranch& other) const {
-    return name().CompareTo(other.name()); 
+    return name().EqualTo(other.name()); 
   }
 
   /**

--- a/include/Framework/TreeDiff/BareBranch.h
+++ b/include/Framework/TreeDiff/BareBranch.h
@@ -69,8 +69,8 @@ class BareBranch {
    *    sequentially and instead looking at this branch entirely.
    * 2. Make sure the number of baskets is the same.
    *    Since the splitting and compression of data is completely deterministic
-   *    in ROOT, *I think* this will only fail if the splitting or compression
-   *    settings of our EventFiles changes.
+   *    in ROOT, *I think* this will only fail if the splitlevel or buffsize of our
+   *    branches change or if the configuration of ROOT's memory changes.
    * 3. Compare the decompressed buffers of each of the baskets in sequence.
    *    If any of the baskets don't match in length (amount of data)
    *    or content (the data itself), we fail the comparison.
@@ -81,6 +81,12 @@ class BareBranch {
    * It also makes intuitive sense that the baskets would be in the same order
    * since the data was generalized and serialized in a deterministic
    * fashion.
+   *
+   * @note This method of comparison assumes that the splitlevel
+   * and buffsize input into the TTree::Branch method when the branches
+   * were being created are the same. In other words, it is likely
+   * that two branches with the same data but different splitlevel
+   * and/or buffsize will fail the comparison.
    *
    * @see getContent for how we get the data from a basket
    * @throws Exceptions if reading buffers for this branch fails.

--- a/include/Framework/TreeDiff/BareBranch.h
+++ b/include/Framework/TreeDiff/BareBranch.h
@@ -1,0 +1,95 @@
+#ifndef FRAMEWORK_TREEDIFF_BAREBRANCH_H
+#define FRAMEWORK_TREEDIFF_BAREBRANCH_H
+
+#include "TFile.h"
+#include "TBranch.h"
+
+namespace framework {
+namespace treediff {
+
+/**
+ * Branch *without* access to the data in C++ form.
+ *
+ * This gives us the ability to access the serialized
+ * data from the corresponding branch of the same name
+ * in the tree.
+ *
+ * We assume that this is the "lowest-level" branch,
+ * i.e. the branch we wrap here *does not* have any
+ * child branches.
+ */
+class BareBranch {
+ public:
+  /**
+   * Wrap a branch and the file it came from
+   * in our class.
+   */
+  BareBranch(TFile* f, TBranch* b) : file_{f}, branch_{b} {}
+
+  /**
+   * Get the name of this branch
+   *
+   * We use the "full" name because lots of
+   * hierachical data is 'split' into sub branches
+   * and the full name will give us the name of
+   * the sub branch and all its parent branches.
+   */
+  const TString name() const {
+    return branch_->GetFullName();
+  }
+
+  /**
+   * Do we and the passed BareBranch have the same name?
+   */
+  bool sameName(const BareBranch& other) const {
+    return name().CompareTo(other.name()); 
+  }
+
+  /**
+   * Do we and the passed BareBranch have the same content?
+   */
+  bool sameContent(const BareBranch& other) const;
+
+  /**
+   * Define equality operator so the symmetric nature
+   * of this comparison is made plain.
+   */
+  bool operator==(const BareBranch& other) const {
+    return sameName(other) and sameContent(other);
+  }
+
+  /**
+   * Get the buffer stored in the passed basket index.
+   *
+   * @note This returns a newly allocated char array,
+   * make sure to clean up after yourself!
+   */
+  char* getContent(int i_basket, int& len) const;
+
+ private:
+
+  /**
+   * The file that we are reading the data from.
+   *
+   * We have to make this mutable because ROOT is crap
+   * and const correctness.
+   *
+   * We only need this handle to be able to use the
+   * TFile::ReadBuffer method which (as the name implies)
+   * does not modify the TFile.
+   */
+  TFile* file_;
+
+  /**
+   * A handle to the branch we are reading.
+   *
+   * We have to make this mutable because ROOT is crap
+   * and const correctness.
+   */
+  TBranch* branch_;
+};
+
+}
+}
+
+#endif // FRAMEWORK_TREEDIFF_BAREBRANCH_H

--- a/include/Framework/TreeDiff/BareBranch.h
+++ b/include/Framework/TreeDiff/BareBranch.h
@@ -21,8 +21,7 @@ namespace treediff {
 class BareBranch {
  public:
   /**
-   * Wrap a branch and the file it came from
-   * in our class.
+   * Wrap a branch and the file it came from in our class.
    */
   BareBranch(TFile* f, TBranch* b) : file_{f}, branch_{b} {}
 
@@ -33,11 +32,18 @@ class BareBranch {
    * hierachical data is 'split' into sub branches
    * and the full name will give us the name of
    * the sub branch and all its parent branches.
+   *
+   * This allows us to remove any potential conflicts
+   * when two different branches may have the same
+   * sub-branch name.
    */
   const TString name() const { return branch_->GetFullName(); }
 
   /**
    * Do we and the passed BareBranch have the same name?
+   *
+   * @param[in] other another BareBranch to compare names with
+   * @returns true if our name and their name match exactly
    */
   bool sameName(const BareBranch& other) const {
     return name().EqualTo(other.name());
@@ -45,31 +51,57 @@ class BareBranch {
 
   /**
    * Do we and the passed BareBranch have the same content?
+   *
+   * This is the heavy duty part, so pay attention.
+   *
+   * 1. Load the baskets of both our branch and their branch into memory.
+   *    This lets ROOT know that we will *not* be reading this file
+   *    sequentially and instead looking at this branch entirely.
+   * 2. Make sure the number of baskets is the same.
+   *    Since the splitting and compression of data is completely deterministic
+   *    in ROOT, this will only fail if the splitting or compression
+   *    settings of our EventFiles changes (probably).
+   * 3. Compare the decompressed buffers of each of the baskets in sequence.
+   *    If any of the baskets don't match in length (amount of data)
+   *    or content (the data itself), we return faile the comparison.
+   * 4. Clean up after ourselves by deleting buffers and dropping baskets.
+   *
+   * @note I assume that our baskets and their baskets are in the same order.
+   * I don't know if this is a safe assumption, but it seems to work.
+   *
+   * @param[in] other another BareBranch to check against
+   * @returns true if our content matches other's perfectly
    */
   bool sameContent(const BareBranch& other) const;
 
-  /**
-   * Define equality operator so the symmetric nature
-   * of this comparison is made plain.
-   */
-  bool operator==(const BareBranch& other) const {
-    return sameName(other) and sameContent(other);
-  }
-
+ private:
   /**
    * Get the buffer stored in the passed basket index.
    *
+   * We do this in two steps.
+   *
+   * 1. Read the serialized data from the file.
+   * 2. Decompress the data (if need-be).
+   *
+   * @see TFile::ReadBuffer for how we read in the data from the file.
+   * @see R__unzip_header and R__unzip for how we decompress our buffer.
+   *
    * @note This returns a newly allocated char array,
    * make sure to clean up after yourself!
+   *
+   * @throws Exception if we can't access the basket for the passed index.
+   * @throws Exception if we can't read the basket from the file we have.
+   * @throws Exception if we aren't able to decompress the buffer.
+   *
+   * @param[in] i_basket Index of basket to read in
+   * @param[out] len Length of buffer read in
+   * @returns newly allocated buffer of length len
    */
   char* getContent(int i_basket, int& len) const;
 
  private:
   /**
    * The file that we are reading the data from.
-   *
-   * We have to make this mutable because ROOT is crap
-   * and const correctness.
    *
    * We only need this handle to be able to use the
    * TFile::ReadBuffer method which (as the name implies)
@@ -80,8 +112,7 @@ class BareBranch {
   /**
    * A handle to the branch we are reading.
    *
-   * We have to make this mutable because ROOT is crap
-   * and const correctness.
+   * Used for getting the list of baskets of data.
    */
   TBranch* branch_;
 };

--- a/include/Framework/TreeDiff/BareTree.h
+++ b/include/Framework/TreeDiff/BareTree.h
@@ -29,8 +29,12 @@ class BareTree {
   /**
    * Generate the list of branches that will need to
    * be compared.
+   *
+   * @param[in] f handle to file we are reading from
+   * @param[in] tree_name name of tree in file to wrap
+   * @param[in] ignore_substrs list of sub-strings of branch names to ignore in any future comparison
    */
-  BareTree(TFile* f, const TString& tree_name);
+  BareTree(TFile* f, const TString& tree_name, const std::vector<TString>& ignore_substrs = {});
 
   /**
    * Do the comparison between two BareTrees.
@@ -38,6 +42,12 @@ class BareTree {
    * We don't modify the actual list of the branches
    * but we do modify the list of branches that are only
    * here and that differ in their data.
+   *
+   * @see BareBranch::sameName and BareBranch::sameContent for
+   * how we compare individual branches.
+   *
+   * @param[in] other Another BareTree to compare ourselves to
+   * @return true if we have the same structure and content as other
    */
   bool compare(const BareTree& other) const;
 
@@ -80,6 +90,13 @@ class BareTree {
     branches_diff_data_.clear();
   }
 
+  /**
+   * Check if the input branch should be ignored.
+   *
+   * @return true if we should skip the branch
+   */
+  bool shouldIgnore(const BareBranch& b) const;
+
  private:
   /**
    * The file that we are reading the data from.
@@ -98,6 +115,14 @@ class BareTree {
    * The list of branches that have no sub-branches.
    */
   std::vector<BareBranch> branches_;
+
+  /**
+   * List of branch name sub-strings to ignore.
+   *
+   * The reason we use sub-strings is to avoid having
+   * to specify the pass name which we encode into the branch name.
+   */
+  std::vector<TString> ignore_substrs_;
 
   /**
    * Branches only in this tree map after a comparison is made.

--- a/include/Framework/TreeDiff/BareTree.h
+++ b/include/Framework/TreeDiff/BareTree.h
@@ -18,6 +18,9 @@ namespace treediff {
  *
  * 1. It is faster than creating the necessary objects.
  * 2. We don't have to import that ROOT dictionary here.
+ * 3. Comparing buffers is safer and less prone to bugs
+ *    than writing custom comparison operators for all
+ *    our objects.
  *
  * In the process of checking the equality of bare trees,
  * we can modify some member variables allowing us to look into
@@ -80,6 +83,13 @@ class BareTree {
    * higher level branches into sub-branches. The sub-branches are
    * actually where all the baskets and data are stored, so we
    * need a list of them.
+   *
+   * This function is recursive because sometimes ROOT is
+   * recursive.
+   *
+   * @param[in] branch_list List of branches 
+   * retrieved from TBranch::GetListOfBranches()
+   * @returns list of flattened branches wrapped in our BareBranch
    */
   std::vector<BareBranch> flatBranchList(TObjArray* branch_list) const;
 

--- a/include/Framework/TreeDiff/BareTree.h
+++ b/include/Framework/TreeDiff/BareTree.h
@@ -25,12 +25,21 @@ namespace treediff {
  * In the process of checking the equality of bare trees,
  * we can modify some member variables allowing us to look into
  * the form of an in-equality much better.
+ *
+ * Similar to regular `diff` or `git diff`,
+ * this method of comparison is really only helpful
+ * if the trees being compared are (in some sense) "close"
+ * to being identical. 
+ *
+ * For example, if the two trees only
+ * differ by their number of entries (say one tree has one
+ * more event than the other), all of the branches will be
+ * listed as having "different content".
  */
 class BareTree {
  public:
   /**
-   * Generate the list of branches that will need to
-   * be compared.
+   * Generate the list of branches that will need to be compared.
    *
    * @param[in] f handle to file we are reading from
    * @param[in] tree_name name of tree in file to wrap
@@ -49,6 +58,12 @@ class BareTree {
    *
    * @see BareBranch::sameName and BareBranch::sameContent for
    * how we compare individual branches.
+   *
+   * @throws Exception if reading buffers in branches fails.
+   *
+   * We warn the user if the two trees being compared are different sizes.
+   * This is because the comparison *will* fail and list *all* branches
+   * as having different content.
    *
    * @param[in] other Another BareTree to compare ourselves to
    * @return true if we have the same structure and content as other
@@ -82,10 +97,11 @@ class BareTree {
    * When ROOT knows how to, it saves space and time by "splitting"
    * higher level branches into sub-branches. The sub-branches are
    * actually where all the baskets and data are stored, so we
-   * need a list of them.
+   * need a list of them. Moreover, sometimes this "splitting"
+   * is done recursively when a top-level class has another
+   * "splitt-able" class as a member.
    *
-   * This function is recursive because sometimes ROOT is
-   * recursive.
+   * This function is recursive because sometimes ROOT is recursive.
    *
    * @param[in] branch_list List of branches 
    * retrieved from TBranch::GetListOfBranches()
@@ -95,6 +111,12 @@ class BareTree {
 
   /**
    * Reset comparison objects
+   *
+   * Currently, this is not needed since both executables that
+   * use this comparison method only execute one comparison;
+   * nevertheless, I could forsee the addition of multiple
+   * comparisons in one run e.g. to do a comparison between
+   * all pairs of three files.
    */
   void newComparison() const {
     branches_only_here_.clear();

--- a/include/Framework/TreeDiff/BareTree.h
+++ b/include/Framework/TreeDiff/BareTree.h
@@ -1,0 +1,118 @@
+#ifndef FRAMEWORK_TREEDIFF_BARETREE_H
+#define FRAMEWORK_TREEDIFF_BARETREE_H
+
+#include <vector>
+
+#include "TString.h"
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/TreeDiff/BareBranch.h"
+
+namespace framework {
+namespace treediff {
+
+/**
+ * Wrapper for TTrees where we only access the serialized
+ * form of the data on the branches. This is convenient
+ * for us because
+ *
+ * 1. It is faster than creating the necessary objects.
+ * 2. We don't have to import that ROOT dictionary here.
+ *
+ * In the process of checking the equality of bare trees,
+ * we can modify some member variables allowing us to look into
+ * the form of an in-equality much better.
+ */
+class BareTree {
+ public:
+  /**
+   * Generate the list of branches that will need to
+   * be compared.
+   */
+  BareTree(TFile* f, const TString& tree_name);
+
+  /**
+   * Do the comparison between two BareTrees.
+   * 
+   * We don't modify the actual list of the branches
+   * but we do modify the list of branches that are only
+   * here and that differ in their data.
+   */
+  bool compare(const BareTree& other) const;
+
+  /**
+   * Get the list of branches that are only in this map.
+   *
+   * @note This is only filled during a comparison!
+   */
+  const std::vector<TString> &getBranchesOnlyHere() const {
+    return branches_only_here_;
+  }
+
+  /**
+   * Get the list of branches that differ in data between
+   * this map and the one most recently compared to it.
+   *
+   * @note This is only filled during a comparison!
+   */
+  const std::vector<TString> &getBranchesDiffData() const {
+    return branches_diff_data_;
+  }
+
+ private:
+  /**
+   * Flatten the hierarchical branch list into lowest level branches
+   * and wrap them in our bare class.
+   *
+   * When ROOT knows how to, it saves space and time by "splitting"
+   * higher level branches into sub-branches. The sub-branches are
+   * actually where all the baskets and data are stored, so we
+   * need a list of them.
+   */
+  std::vector<BareBranch> flatBranchList(TObjArray* branch_list) const;
+
+  /**
+   * Reset comparison objects
+   */
+  void newComparison() const {
+    branches_only_here_.clear();
+    branches_diff_data_.clear();
+  }
+
+ private:
+  /**
+   * The file that we are reading the data from.
+   */
+  TFile* file_;
+
+  /**
+   * A handle to the tree we are reading.
+   *
+   * @note Not sure if this is needed,
+   * only used to get the list of branches.
+   */
+  TTree* tree_;
+
+  /**
+   * The list of branches that have no sub-branches.
+   */
+  std::vector<BareBranch> branches_;
+
+  /**
+   * Branches only in this tree map after a comparison is made.
+   */
+  mutable std::vector<TString> branches_only_here_;
+
+  /**
+   * Branches that have different data in this tree map and
+   * the other after a comparison is made.
+   */
+  mutable std::vector<TString> branches_diff_data_;
+
+};
+
+}
+}
+
+#endif // FRAMEWORK_TREEDIFF_BARETREE_H

--- a/include/Framework/TreeDiff/BareTree.h
+++ b/include/Framework/TreeDiff/BareTree.h
@@ -3,11 +3,10 @@
 
 #include <vector>
 
-#include "TString.h"
-#include "TFile.h"
-#include "TTree.h"
-
 #include "Framework/TreeDiff/BareBranch.h"
+#include "TFile.h"
+#include "TString.h"
+#include "TTree.h"
 
 namespace framework {
 namespace treediff {
@@ -32,13 +31,15 @@ class BareTree {
    *
    * @param[in] f handle to file we are reading from
    * @param[in] tree_name name of tree in file to wrap
-   * @param[in] ignore_substrs list of sub-strings of branch names to ignore in any future comparison
+   * @param[in] ignore_substrs list of sub-strings of branch names to ignore in
+   * any future comparison
    */
-  BareTree(TFile* f, const TString& tree_name, const std::vector<TString>& ignore_substrs = {});
+  BareTree(TFile* f, const TString& tree_name,
+           const std::vector<TString>& ignore_substrs = {});
 
   /**
    * Do the comparison between two BareTrees.
-   * 
+   *
    * We don't modify the actual list of the branches
    * but we do modify the list of branches that are only
    * here and that differ in their data.
@@ -56,7 +57,7 @@ class BareTree {
    *
    * @note This is only filled during a comparison!
    */
-  const std::vector<TString> &getBranchesOnlyHere() const {
+  const std::vector<TString>& getBranchesOnlyHere() const {
     return branches_only_here_;
   }
 
@@ -66,7 +67,7 @@ class BareTree {
    *
    * @note This is only filled during a comparison!
    */
-  const std::vector<TString> &getBranchesDiffData() const {
+  const std::vector<TString>& getBranchesDiffData() const {
     return branches_diff_data_;
   }
 
@@ -134,10 +135,9 @@ class BareTree {
    * the other after a comparison is made.
    */
   mutable std::vector<TString> branches_diff_data_;
-
 };
 
-}
-}
+}  // namespace treediff
+}  // namespace framework
 
-#endif // FRAMEWORK_TREEDIFF_BARETREE_H
+#endif  // FRAMEWORK_TREEDIFF_BARETREE_H

--- a/include/Framework/TreeDiff/Compare.h
+++ b/include/Framework/TreeDiff/Compare.h
@@ -1,0 +1,42 @@
+#ifndef FRAMEWORK_TREEDIFF_COMPARE_H
+#define FRAMEWORK_TREEDIFF_COMPARE_H
+
+#include <vector>
+
+#include "TString.h"
+
+namespace framework {
+namespace treediff {
+
+/// return status when we failed to run
+static const int FAILED_TO_RUN{127};
+
+/// return status for a perfect match
+static const int MATCH{0};
+
+/// return status for a successful run but failed match
+static const int MISMATCH{1};
+
+/**
+ * Isolate comparison function after parsing
+ * the command line arguments. This allows us
+ * to define different executables sharing the
+ * same basic comparison process.
+ *
+ * @see FAILED_TO_RUN, MATCH, and MISMATCH for
+ * the different return statuses.
+ *
+ * @param[in] f1 name of first file
+ * @param[in] f2 name of second file
+ * @param[in] trees name of tress to compare between files
+ * @param[in] to_ignore list of substrings of branches to ignore
+ * @return exit status for program
+ */
+int compare(const TString& f1, const TString& f2,
+            const std::vector<TString>& trees,
+            const std::vector<TString>& to_ignore);
+
+}
+}
+
+#endif

--- a/include/Framework/TreeDiff/Compare.h
+++ b/include/Framework/TreeDiff/Compare.h
@@ -17,12 +17,80 @@ namespace framework {
  * Similar to regular `diff` or `git diff`,
  * this method of comparison is really only helpful
  * if the trees being compared are (in some sense) "close"
- * to being identical. 
+ * to being identical.
  *
  * For example, if the two trees only
  * differ by their number of entries (say one tree has one
  * more event than the other), all of the branches will be
  * listed as having "different content".
+ *
+ * I don't really know where else to put this information,
+ * so I'm putting it here.
+ *
+ * # ROOT Serialization Primer
+ * In order to understand what I'm doing here; first, you need to understand how
+ * ROOT serializes a TTree.
+ *
+ * ### Splitting
+ * Each TTree has TBranches created through the TTree::Branch method. If allowed
+ * using a non-zero "split level", ROOT will "split" TBranches of complicated
+ * objects into several parallel TBranches of less complicated objects. For
+ * example, a TBranch of a struct MyObj { int my_int_; float my_float_; }; would
+ * be split into two sub-branches: one for my_int_ and one for my_float_. The
+ * splitting process is recursive. If a TBranch has a sub-branch that is a
+ * complicated object itself, the sub-branch can also split into less
+ * complicated sub-branches.
+ *
+ * Only the lowest-level branches (branches with no sub-branches) follow data
+ * and serialize it into the output file. The higher level branches (branches
+ * with sub-branches) are only useful for interfacing between our complicated,
+ * hierarchical C++ objects and the simple, serialized ones and zeros in the
+ * file. This is crucial. For our purposes here, we don't care about the
+ * higher-level branches because we only want to look at the simple, serialized
+ * data that is easy to compare. Since the splitlevel changes what the
+ * lowest-level branches are, we will need to assume that the splitlevel input
+ * is the same for branches of the same name.
+ *
+ * Inside of this namespace, when I say "branch", assume I'm talking about only
+ * these lowest-level branches.
+ *
+ * ### Baskets
+ * Branches whose data is actually being serialized into/outof the file often
+ * contain large amounts of data that cannot be loaded into memory all at once.
+ * In order to get around this difficulty, ROOT "chunks" branches into baskets
+ * (TBaskets) that are the objects serialized into the file. The size of these
+ * baskets is configurable and is called buffsize at the TTree::Branch level.
+ * Since the number of the baskets and which data is in which basket changes
+ * depending on the size of these baskets, we will need to assume that the
+ * buffsize input is the same for branches of the same name.
+ *
+ * The TBasket is where the data from its corresponding TBranch is compressed
+ * (or decompressed), so getting down the the TBasket level is where we want to
+ * be. Note: The TBranch serializes the object before giving the data to the
+ * TBasket, so the TBasket doesn't need to know the type of object that TBranch
+ * is following.
+ *
+ * ### Summary
+ * In summary, each TTree has several TBranches. Each TBranch may be split into
+ * several child TBranches (recursively) depending on the splitlevel input. The
+ * bottom TBranches have several TBaskets. Each TBasket has one or more entries
+ * in the corresponding TBranch depending on the memory size of the TBranch
+ * entries. How the entires in the TBranch are partitioned into TBaskets is
+ * controlled by the buffsize input.
+ *
+ * ### Objects in General
+ * Finally, I need to make a comment about how ROOT writes objects to files.
+ * This applies to any object that ROOT writes and TBaskets are a special case.
+ * ROOT writes objects in two stages. First, ROOT writes a "header" which
+ * contains object details such as the name of the object, its class, the size
+ * of the object, it's location in the file, and other information we won't use.
+ * This "header" is also called a "key" in ROOT terminology; hence, why you see
+ * TKeys floating around. The second stage, immediately after this header, is
+ * the serialized (usually also compressed) data. At the end of the day, once we
+ * have this "key", we can access the serialized data off the file directly.
+ * TBasket is actually a specialization of TKey for interfacing with TBranches,
+ * so you won't see TKey in the code above; however, you will see me calling
+ * TKey methods from the derived class TBasket.
  */
 namespace treediff {
 
@@ -51,6 +119,14 @@ static const int MISMATCH{1};
  * This function catches all of our own Execeptions,
  * so it safe to simply return this fuction at the end
  * of your main (after parsing any command-line inputs).
+ *
+ * ## Known Limitations
+ * The reasons for these limitations depend on how ROOT serializes TTrees.
+ *
+ * @see treediff for an explanation on where these limitations come from.
+ *
+ * 1. Two event trees need to have the same pass name to be compared well.
+ * 2. Two branches need to have the same splitlevel and buffsize. 
  *
  * @param[in] f1 name of first file
  * @param[in] f2 name of second file

--- a/include/Framework/TreeDiff/Compare.h
+++ b/include/Framework/TreeDiff/Compare.h
@@ -6,6 +6,14 @@
 #include "TString.h"
 
 namespace framework {
+
+/**
+ * @namespace treediff
+ *
+ * An extension to framework for comparing
+ * trees in two separate files that are hypothesized
+ * to be identical.
+ */
 namespace treediff {
 
 /// return status when we failed to run
@@ -25,6 +33,10 @@ static const int MISMATCH{1};
  *
  * @see FAILED_TO_RUN, MATCH, and MISMATCH for
  * the different return statuses.
+ *
+ * @see framework::treediff::BareTree for how
+ * we 'import' the data and compare it across
+ * files.
  *
  * @param[in] f1 name of first file
  * @param[in] f2 name of second file

--- a/include/Framework/TreeDiff/Compare.h
+++ b/include/Framework/TreeDiff/Compare.h
@@ -13,6 +13,16 @@ namespace framework {
  * An extension to framework for comparing
  * trees in two separate files that are hypothesized
  * to be identical.
+ *
+ * Similar to regular `diff` or `git diff`,
+ * this method of comparison is really only helpful
+ * if the trees being compared are (in some sense) "close"
+ * to being identical. 
+ *
+ * For example, if the two trees only
+ * differ by their number of entries (say one tree has one
+ * more event than the other), all of the branches will be
+ * listed as having "different content".
  */
 namespace treediff {
 
@@ -37,6 +47,10 @@ static const int MISMATCH{1};
  * @see framework::treediff::BareTree for how
  * we 'import' the data and compare it across
  * files.
+ *
+ * This function catches all of our own Execeptions,
+ * so it safe to simply return this fuction at the end
+ * of your main (after parsing any command-line inputs).
  *
  * @param[in] f1 name of first file
  * @param[in] f2 name of second file

--- a/include/Framework/TreeDiff/Compare.h
+++ b/include/Framework/TreeDiff/Compare.h
@@ -36,7 +36,7 @@ int compare(const TString& f1, const TString& f2,
             const std::vector<TString>& trees,
             const std::vector<TString>& to_ignore);
 
-}
-}
+}  // namespace treediff
+}  // namespace framework
 
 #endif

--- a/src/Framework/Testing/test_fire.cxx
+++ b/src/Framework/Testing/test_fire.cxx
@@ -1,0 +1,150 @@
+
+//----------------//
+//   C++ StdLib   //
+//----------------//
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <iostream>
+#include <set>
+
+#include "TString.h"
+
+//-------------//
+//   ldmx-sw   //
+//-------------//
+#include "Framework/Exception/Exception.h"
+#include "Framework/TreeDiff/Compare.h"
+#include "Framework/ConfigurePython.h"
+#include "Framework/Process.h"
+
+/**
+ * Print the usage of this executable to std::cout
+ */
+static inline void usage() {
+  std::cout 
+    << "Use: test-fire [-h,--help] [-i,--ignore class_name]\n"
+    << "               {config.py} {output.root}"
+    << "-h,--help  Print this help message and exit.\n"
+    << "-i,--ignore\n"
+    << "           Name of class to ignore. Can specify more than once.\n"
+    << "config.py  Configuration script to run.\n"
+    << "           Should take the name of the output file as its only argument."
+    << "output.root\n"
+    << "           Ouput file that config.py should generate."
+    << std::endl;
+}
+
+/**
+ * Helper function for configuration error where
+ * an input flag isn't provided its required argument.
+ */
+static inline void needsArgAfter(const TString& arg) {
+  usage();
+  std::cout 
+    << "** Flag " << arg 
+    << " requires an argument after it. **"
+    << std::endl;
+}
+
+/**
+ * The trees in an output file that we should check.
+ * These need to match the names of the trees in an
+ * output file _exactly_.
+ */
+static const std::vector<TString> trees_to_check = {
+  "LDMX_Events",
+  "LDMX_Run"
+};
+
+/**
+ * test-fire
+ *
+ * Executable to check that a certain configuration script
+ * still produces the same output event file.
+ */
+int main(int argc, char* argv[]) {
+  std::vector<TString> to_ignore;
+  std::vector<TString> positional_args;
+  for (int arg_i{1}; arg_i < argc; arg_i++) {
+    TString arg{argv[arg_i]};
+    if (arg.EqualTo("-h") or arg.EqualTo("--help")) {
+      usage();
+      return 0;
+    } else if (arg.EqualTo("-i") or arg.EqualTo("--ignore")) {
+      if (arg_i + 1 > argc or argv[arg_i + 1][0] == '-') {
+        needsArgAfter(arg);
+        return framework::treediff::FAILED_TO_RUN;
+      }
+      to_ignore.emplace_back(argv[arg_i + 1]);
+      // shift arg index to skip name after flag
+      arg_i++;
+    } else {
+      positional_args.emplace_back(arg);
+    }
+  }
+
+  if (positional_args.size() != 2) {
+    usage();
+    std::cerr << "** Need to specify two files : "
+      << "a config script and the expected output file **" << std::endl;
+  }
+
+  TString config = positional_args.at(0);
+  TString output_config_should_match = positional_args.at(1);
+  TString output_config_generated = output_config_should_match + ".test";
+
+  char *cstr_translation = new char[output_config_generated.Length()+1];
+  strcpy(cstr_translation, output_config_generated.Data());
+  char *config_args[1] = { cstr_translation };
+
+  // CLI arguments have been parsed, let's run the process
+
+  framework::ProcessHandle p;
+  try {
+    framework::ConfigurePython cfg(config.Data(),config_args,1);
+    delete [] cstr_translation;
+    p = cfg.makeProcess();
+  } catch (framework::exception::Exception& e) {
+    std::cerr << "Configuration Error [" << e.name() << "] : " << e.message()
+              << std::endl;
+    std::cerr << "  at " << e.module() << ":" << e.line() << " in "
+              << e.function() << std::endl;
+    std::cerr << "Stack trace: " << std::endl << e.stackTrace();
+    return framework::treediff::FAILED_TO_RUN;
+  }
+
+  // If Ctrl-c is used, immediately exit the application.
+  struct sigaction act;
+  memset(&act, '\0', sizeof(act));
+  if (sigaction(SIGINT, &act, NULL) < 0) {
+    perror("sigaction");
+    return framework::treediff::FAILED_TO_RUN;
+  }
+
+  try {
+    p->run();
+  } catch (framework::exception::Exception& e) {
+    // Process::run opens up the logging using the parameters passed to it from
+    // python
+    //  if an Exception is thrown, we haven't gotten to the end of Process::run
+    //  where logging is closed, so we can do one more error message and then
+    //  close it.
+    auto theLog_{framework::logging::makeLogger(
+        "test-fire")};  // ldmx_log macro needs this variable to be named 'theLog_'
+    ldmx_log(fatal) << "[" << e.name() << "] : " << e.message() << "\n"
+                    << "  at " << e.module() << ":" << e.line() << " in "
+                    << e.function() << "\nStack trace: " << std::endl
+                    << e.stackTrace();
+    framework::logging::close();
+    return framework::treediff::FAILED_TO_RUN;  // return non-zero error-status
+  }
+
+  // get here when we successfully finish running.
+  // This means we can move on to comparison
+
+  return framework::treediff::compare(
+      output_config_should_match, output_config_generated,
+      trees_to_check, to_ignore);
+}

--- a/src/Framework/Testing/test_fire.cxx
+++ b/src/Framework/Testing/test_fire.cxx
@@ -24,11 +24,11 @@
  */
 static inline void usage() {
   std::cout 
-    << "Use: test-fire [-h,--help] [-i,--ignore class_name]\n"
-    << "               {config.py} {output.root}"
+    << "Use: test-fire [-h,--help] [-i,--ignore b0]\n"
+    << "               {config.py} {output.root}\n"
     << "-h,--help  Print this help message and exit.\n"
     << "-i,--ignore\n"
-    << "           Name of class to ignore. Can specify more than once.\n"
+    << "           Branch name substring to ignore. Can specify more than once.\n"
     << "config.py  Configuration script to run.\n"
     << "           Should take the name of the output file as its only argument."
     << "output.root\n"
@@ -65,7 +65,14 @@ static const std::vector<TString> trees_to_check = {
  * still produces the same output event file.
  */
 int main(int argc, char* argv[]) {
-  std::vector<TString> to_ignore;
+  // start with an ignore list that ignores
+  // the time stamps
+  std::vector<TString> to_ignore = {
+    "EventHeader.timestamp_",
+    "RunHeader.runStart_",
+    "RunHeader.runEnd_",
+    "RunHeader.softwareTag_"
+  };
   std::vector<TString> positional_args;
   for (int arg_i{1}; arg_i < argc; arg_i++) {
     TString arg{argv[arg_i]};
@@ -87,8 +94,12 @@ int main(int argc, char* argv[]) {
 
   if (positional_args.size() != 2) {
     usage();
+    std::cerr << " Positional Arguments: ";
+    for (const auto& a : positional_args) std::cerr << a << " ";
+    std::cerr << std::endl;
     std::cerr << "** Need to specify two files : "
       << "a config script and the expected output file **" << std::endl;
+    return framework::treediff::FAILED_TO_RUN;
   }
 
   TString config = positional_args.at(0);

--- a/src/Framework/Testing/test_fire.cxx
+++ b/src/Framework/Testing/test_fire.cxx
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+
 #include <iostream>
 #include <set>
 
@@ -14,26 +15,27 @@
 //-------------//
 //   ldmx-sw   //
 //-------------//
-#include "Framework/Exception/Exception.h"
-#include "Framework/TreeDiff/Compare.h"
 #include "Framework/ConfigurePython.h"
+#include "Framework/Exception/Exception.h"
 #include "Framework/Process.h"
+#include "Framework/TreeDiff/Compare.h"
 
 /**
  * Print the usage of this executable to std::cout
  */
 static inline void usage() {
-  std::cout 
-    << "Use: test-fire [-h,--help] [-i,--ignore b0]\n"
-    << "               {config.py} {output.root}\n"
-    << "-h,--help  Print this help message and exit.\n"
-    << "-i,--ignore\n"
-    << "           Branch name substring to ignore. Can specify more than once.\n"
-    << "config.py  Configuration script to run.\n"
-    << "           Should take the name of the output file as its only argument."
-    << "output.root\n"
-    << "           Ouput file that config.py should generate."
-    << std::endl;
+  std::cout << "Use: test-fire [-h,--help] [-i,--ignore b0]\n"
+            << "               {config.py} {output.root}\n"
+            << "-h,--help  Print this help message and exit.\n"
+            << "-i,--ignore\n"
+            << "           Branch name substring to ignore. Can specify more "
+               "than once.\n"
+            << "config.py  Configuration script to run.\n"
+            << "           Should take the name of the output file as its only "
+               "argument."
+            << "output.root\n"
+            << "           Ouput file that config.py should generate."
+            << std::endl;
 }
 
 /**
@@ -42,10 +44,8 @@ static inline void usage() {
  */
 static inline void needsArgAfter(const TString& arg) {
   usage();
-  std::cout 
-    << "** Flag " << arg 
-    << " requires an argument after it. **"
-    << std::endl;
+  std::cout << "** Flag " << arg << " requires an argument after it. **"
+            << std::endl;
 }
 
 /**
@@ -53,10 +53,7 @@ static inline void needsArgAfter(const TString& arg) {
  * These need to match the names of the trees in an
  * output file _exactly_.
  */
-static const std::vector<TString> trees_to_check = {
-  "LDMX_Events",
-  "LDMX_Run"
-};
+static const std::vector<TString> trees_to_check = {"LDMX_Events", "LDMX_Run"};
 
 /**
  * test-fire
@@ -67,12 +64,9 @@ static const std::vector<TString> trees_to_check = {
 int main(int argc, char* argv[]) {
   // start with an ignore list that ignores
   // the time stamps
-  std::vector<TString> to_ignore = {
-    "EventHeader.timestamp_",
-    "RunHeader.runStart_",
-    "RunHeader.runEnd_",
-    "RunHeader.softwareTag_"
-  };
+  std::vector<TString> to_ignore = {"EventHeader.timestamp_",
+                                    "RunHeader.runStart_", "RunHeader.runEnd_",
+                                    "RunHeader.softwareTag_"};
   std::vector<TString> positional_args;
   for (int arg_i{1}; arg_i < argc; arg_i++) {
     TString arg{argv[arg_i]};
@@ -98,7 +92,7 @@ int main(int argc, char* argv[]) {
     for (const auto& a : positional_args) std::cerr << a << " ";
     std::cerr << std::endl;
     std::cerr << "** Need to specify two files : "
-      << "a config script and the expected output file **" << std::endl;
+              << "a config script and the expected output file **" << std::endl;
     return framework::treediff::FAILED_TO_RUN;
   }
 
@@ -106,16 +100,16 @@ int main(int argc, char* argv[]) {
   TString output_config_should_match = positional_args.at(1);
   TString output_config_generated = output_config_should_match + ".test";
 
-  char *cstr_translation = new char[output_config_generated.Length()+1];
+  char* cstr_translation = new char[output_config_generated.Length() + 1];
   strcpy(cstr_translation, output_config_generated.Data());
-  char *config_args[1] = { cstr_translation };
+  char* config_args[1] = {cstr_translation};
 
   // CLI arguments have been parsed, let's run the process
 
   framework::ProcessHandle p;
   try {
-    framework::ConfigurePython cfg(config.Data(),config_args,1);
-    delete [] cstr_translation;
+    framework::ConfigurePython cfg(config.Data(), config_args, 1);
+    delete[] cstr_translation;
     p = cfg.makeProcess();
   } catch (framework::exception::Exception& e) {
     std::cerr << "Configuration Error [" << e.name() << "] : " << e.message()
@@ -143,7 +137,8 @@ int main(int argc, char* argv[]) {
     //  where logging is closed, so we can do one more error message and then
     //  close it.
     auto theLog_{framework::logging::makeLogger(
-        "test-fire")};  // ldmx_log macro needs this variable to be named 'theLog_'
+        "test-fire")};  // ldmx_log macro needs this variable to be named
+                        // 'theLog_'
     ldmx_log(fatal) << "[" << e.name() << "] : " << e.message() << "\n"
                     << "  at " << e.module() << ":" << e.line() << " in "
                     << e.function() << "\nStack trace: " << std::endl
@@ -155,7 +150,7 @@ int main(int argc, char* argv[]) {
   // get here when we successfully finish running.
   // This means we can move on to comparison
 
-  return framework::treediff::compare(
-      output_config_should_match, output_config_generated,
-      trees_to_check, to_ignore);
+  return framework::treediff::compare(output_config_should_match,
+                                      output_config_generated, trees_to_check,
+                                      to_ignore);
 }

--- a/src/Framework/Testing/test_fire.cxx
+++ b/src/Framework/Testing/test_fire.cxx
@@ -32,7 +32,7 @@ static inline void usage() {
                "than once.\n"
             << "config.py  Configuration script to run.\n"
             << "           Should take the name of the output file as its only "
-               "argument."
+               "argument.\n"
             << "output.root\n"
             << "           Ouput file that config.py should generate."
             << std::endl;
@@ -151,6 +151,7 @@ int main(int argc, char* argv[]) {
   // This means we can move on to comparison
 
   return framework::treediff::compare(output_config_should_match,
-                                      output_config_generated, trees_to_check,
+                                      output_config_generated, 
+                                      trees_to_check,
                                       to_ignore);
 }

--- a/src/Framework/TreeDiff/BareBranch.cxx
+++ b/src/Framework/TreeDiff/BareBranch.cxx
@@ -1,4 +1,5 @@
 
+#include <iostream>
 #include <cstring>
 
 #include "RZip.h"
@@ -25,7 +26,7 @@ bool BareBranch::sameContent(const BareBranch& other) const {
     // probably due to change in compression level/algo
     return false;
   }
-  
+
   /**
    * WARN
    * We are assuming that our baskets and their baskets
@@ -80,6 +81,7 @@ char* BareBranch::getContent(int i_basket, int& len) const {
         + " from branch " + name() + " in file " + file_->GetName()).Data());
   }
 
+  len = compressed_len;
   return compressed_content;
   /*
   char *content;

--- a/src/Framework/TreeDiff/BareBranch.cxx
+++ b/src/Framework/TreeDiff/BareBranch.cxx
@@ -80,6 +80,8 @@ char* BareBranch::getContent(int i_basket, int& len) const {
         + " from branch " + name() + " in file " + file_->GetName()).Data());
   }
 
+  return compressed_content;
+  /*
   char *content;
   if (basket->GetObjlen() > compressed_len) {
     //need to de-compress
@@ -116,6 +118,7 @@ char* BareBranch::getContent(int i_basket, int& len) const {
   delete [] compressed_content;
 
   return content;
+  */
 }
 
 }

--- a/src/Framework/TreeDiff/BareBranch.cxx
+++ b/src/Framework/TreeDiff/BareBranch.cxx
@@ -1,0 +1,122 @@
+
+#include <cstring>
+
+#include "RZip.h"
+#include "TBasket.h"
+
+#include "Framework/Exception/Exception.h"
+#include "Framework/TreeDiff/BareBranch.h"
+
+namespace framework {
+namespace treediff {
+
+bool BareBranch::sameContent(const BareBranch& other) const {
+  // load all of the baskets of this branch into memory
+  // ROOT groups data on branches into 'baskets' in order
+  // to keep the current amount of memory in use below 
+  // a certain threshold, each basket corresponds to a
+  // certain number of entries in the branch compressed
+  // and saved into the output file
+  int num_our_baskets = this->branch_->LoadBaskets();
+  int num_their_baskets = other.branch_->LoadBaskets();
+
+  if (num_our_baskets != num_their_baskets) {
+    // mismatching number of baskets
+    // probably due to change in compression level/algo
+    return false;
+  }
+  
+  /**
+   * WARN
+   * We are assuming that our baskets and their baskets
+   * are in the same order!! I don't know if this is a safe
+   * assumption.
+   */
+  bool content_match{true};
+  for (int i_basket{0}; i_basket < num_our_baskets; i_basket++) {
+    int our_len{0}, their_len{0};
+    char* our_buff   = this->getContent(i_basket, our_len);
+    char* their_buff = other.getContent(i_basket, their_len);
+
+    content_match = (our_len == their_len) and 
+      (memcmp(our_buff, their_buff, our_len) == 0);
+
+    delete[] our_buff;
+    delete[] their_buff;
+
+    // leave on first failure
+    if (not content_match) break;
+  }
+  
+  // make sure to drop all our baskets
+  // so that ROOT knows we don't care about those objects
+  // anymore
+  this->branch_->DropBaskets("all");
+  other.branch_->DropBaskets("all");
+
+  // content match will stay true only
+  // if all baskets have the same size
+  // and content bytes
+  return content_match;
+}
+
+char* BareBranch::getContent(int i_basket, int& len) const {
+  TBasket* basket = branch_->GetBasket(i_basket);
+  if (not basket) {
+    EXCEPTION_RAISE("NullBasket",
+        ("Received a NULL basket for branch " + name()
+        + " and basket index " + std::to_string(i_basket)).Data());
+  }
+
+  int compressed_len = basket->GetNbytes() - basket->GetKeylen();
+  char *compressed_content = new char[compressed_len];
+  if (file_->ReadBuffer(compressed_content,
+        basket->GetSeekKey()+basket->GetKeylen(),
+        compressed_len)) {
+    // return status of 1 is a failure
+    delete [] compressed_content;
+    EXCEPTION_RAISE("ReadFail",
+        ("Failure to read basked " + std::to_string(i_basket)
+        + " from branch " + name() + " in file " + file_->GetName()).Data());
+  }
+
+  char *content;
+  if (basket->GetObjlen() > compressed_len) {
+    //need to de-compress
+    len = basket->GetObjlen();
+    content = new char[len];
+
+    // IDK what these mean, got to look it up
+    int nin, nout{0}, noutot{0}, ncontent;
+    while (true) {
+      // get information on how content was compressed
+      R__unzip_header(&nin, (unsigned char *)content, &ncontent);
+      // Actually uncompress some content
+      R__unzip(&nin, (unsigned char *)content, &ncontent, (unsigned char *)compressed_content, &nout);
+      if (!nout) {
+        //all done
+        break;
+      }
+      noutot += nout;
+      if (noutot >= len) {
+        // all done
+        break;
+      }
+      compressed_content += nin;
+      content += nout;
+    }
+
+  } else {
+    //don't need to de-compress
+    len = compressed_len;
+    content = new char[len];
+    memcpy(content, compressed_content, len);
+  }
+
+  delete [] compressed_content;
+
+  return content;
+}
+
+}
+}

--- a/src/Framework/TreeDiff/BareTree.cxx
+++ b/src/Framework/TreeDiff/BareTree.cxx
@@ -7,22 +7,25 @@
 namespace framework {
 namespace treediff {
 
-BareTree::BareTree(TFile* f, const TString &tree_name) : file_{f} {
-
+BareTree::BareTree(TFile* f, const TString& tree_name,
+                   const std::vector<TString>& ignore_substrs)
+    : file_{f}, ignore_substrs_{ignore_substrs} {
   // first we get the tree from the file
-  // and get the (flattened) branch list
-  tree_     = (TTree*)file_->Get(tree_name);
+  tree_ = (TTree*)file_->Get(tree_name);
   
+  // make sure we got a tree
   if (not tree_) {
     EXCEPTION_RAISE("NullTree",
         ("No tree named '" + tree_name + "' exists in file '"
         + file_->GetName() + "'.").Data());
   }
   
+  // get the (flattened) list of branches wrapped with BareBranch
   branches_ = flatBranchList(tree_->GetListOfBranches());
 }
 
 bool BareTree::compare(const BareTree& other) const {
+  // clear the diff-data from any old comparisons
   this->newComparison();
   other.newComparison();
 
@@ -32,31 +35,45 @@ bool BareTree::compare(const BareTree& other) const {
 
   // let's go through these branches
   for (const BareBranch& our_br : branches_) {
+    // skip branches that match a pattern in the ignore list
+    if (shouldIgnore(our_br)) continue;
+
+    // this branch shouldn't be ignored, so let's try to find
+    // it in the other tree
     bool found_name_match{false};
     for (const BareBranch& their_br : other.branches_) {
+      // check if current pair of branches have the same name
       if (our_br.sameName(their_br)) {
         found_name_match = true;
         match_found.insert(their_br.name());
         if (not our_br.sameContent(their_br)) {
+          // same name branches but not same content
           this->branches_diff_data_.push_back(our_br.name());
           other.branches_diff_data_.push_back(our_br.name());
         }
-        break;
-      }
-    }
+        break; // leave after we find a name match
+      } // same name
+    }   // loop over their branches
 
     if (not found_name_match) {
+      // we weren't able to find a name match for this branch
       branches_only_here_.push_back(our_br.name());
     }
-  } // loop over branches
+  } // loop over our branches
 
   // check for branches only on the other tree
   for (const BareBranch& their_br : other.branches_) {
-    if (match_found.find(their_br.name()) == match_found.end()) {
+    // if branch is should not be ignored AND we couldn't
+    // find a match, then this branch is only in the other tree
+    if (not shouldIgnore(their_br) and
+        match_found.find(their_br.name()) == match_found.end()
+    ) {
       other.branches_only_here_.push_back(their_br.name());
-    }
-  }
+    } // their branch was not found here
+  }   // loop over their branches
 
+  // perfect match is only when all three
+  // containers of differences are empty
   return (branches_only_here_.empty() 
           and branches_diff_data_.empty() 
           and other.branches_only_here_.empty());
@@ -75,6 +92,13 @@ std::vector<BareBranch> BareTree::flatBranchList(TObjArray* list) const {
     }
   }
   return flattened_list;
+}
+
+bool BareTree::shouldIgnore(const BareBranch& b) const {
+  for (auto const& name_substr : ignore_substrs_) {
+    if (b.name().Contains(name_substr)) return true;
+  }
+  return false;
 }
 
 }

--- a/src/Framework/TreeDiff/BareTree.cxx
+++ b/src/Framework/TreeDiff/BareTree.cxx
@@ -1,0 +1,81 @@
+
+#include "Framework/TreeDiff/BareTree.h"
+#include "Framework/Exception/Exception.h"
+
+#include <set>
+
+namespace framework {
+namespace treediff {
+
+BareTree::BareTree(TFile* f, const TString &tree_name) : file_{f} {
+
+  // first we get the tree from the file
+  // and get the (flattened) branch list
+  tree_     = (TTree*)file_->Get(tree_name);
+  
+  if (not tree_) {
+    EXCEPTION_RAISE("NullTree",
+        ("No tree named '" + tree_name + "' exists in file '"
+        + file_->GetName() + "'.").Data());
+  }
+  
+  branches_ = flatBranchList(tree_->GetListOfBranches());
+}
+
+bool BareTree::compare(const BareTree& other) const {
+  this->newComparison();
+  other.newComparison();
+
+  // store branch names where we found a name-match
+  // between the trees
+  std::set<TString> match_found;
+
+  // let's go through these branches
+  for (const BareBranch& our_br : branches_) {
+    bool found_name_match{false};
+    for (const BareBranch& their_br : other.branches_) {
+      if (our_br.sameName(their_br)) {
+        found_name_match = true;
+        match_found.insert(their_br.name());
+        if (not our_br.sameContent(their_br)) {
+          this->branches_diff_data_.push_back(our_br.name());
+          other.branches_diff_data_.push_back(our_br.name());
+        }
+        break;
+      }
+    }
+
+    if (not found_name_match) {
+      branches_only_here_.push_back(our_br.name());
+    }
+  } // loop over branches
+
+  // check for branches only on the other tree
+  for (const BareBranch& their_br : other.branches_) {
+    if (match_found.find(their_br.name()) == match_found.end()) {
+      other.branches_only_here_.push_back(their_br.name());
+    }
+  }
+
+  return (branches_only_here_.empty() 
+          and branches_diff_data_.empty() 
+          and other.branches_only_here_.empty());
+}
+
+std::vector<BareBranch> BareTree::flatBranchList(TObjArray* list) const {
+  std::vector<BareBranch> flattened_list;
+  for (unsigned int i=0; i < list->GetEntries(); i++) {
+    TBranch* sub_branch = (TBranch*)list->At(i);
+    if (sub_branch->GetListOfBranches()->GetEntries() > 0) {
+      //recursion
+      std::vector<BareBranch> sub_list{flatBranchList(sub_branch->GetListOfBranches())};
+      flattened_list.insert( flattened_list.end(), sub_list.begin(), sub_list.end());
+    } else {
+      flattened_list.emplace_back(file_,sub_branch);
+    }
+  }
+  return flattened_list;
+}
+
+}
+}

--- a/src/Framework/TreeDiff/BareTree.cxx
+++ b/src/Framework/TreeDiff/BareTree.cxx
@@ -1,8 +1,9 @@
 
 #include "Framework/TreeDiff/BareTree.h"
-#include "Framework/Exception/Exception.h"
 
 #include <set>
+
+#include "Framework/Exception/Exception.h"
 
 namespace framework {
 namespace treediff {
@@ -12,14 +13,14 @@ BareTree::BareTree(TFile* f, const TString& tree_name,
     : file_{f}, ignore_substrs_{ignore_substrs} {
   // first we get the tree from the file
   tree_ = (TTree*)file_->Get(tree_name);
-  
+
   // make sure we got a tree
   if (not tree_) {
-    EXCEPTION_RAISE("NullTree",
-        ("No tree named '" + tree_name + "' exists in file '"
-        + file_->GetName() + "'.").Data());
+    EXCEPTION_RAISE("NullTree", ("No tree named '" + tree_name +
+                                 "' exists in file '" + file_->GetName() + "'.")
+                                    .Data());
   }
-  
+
   // get the (flattened) list of branches wrapped with BareBranch
   branches_ = flatBranchList(tree_->GetListOfBranches());
 }
@@ -51,44 +52,44 @@ bool BareTree::compare(const BareTree& other) const {
           this->branches_diff_data_.push_back(our_br.name());
           other.branches_diff_data_.push_back(our_br.name());
         }
-        break; // leave after we find a name match
-      } // same name
-    }   // loop over their branches
+        break;  // leave after we find a name match
+      }         // same name
+    }           // loop over their branches
 
     if (not found_name_match) {
       // we weren't able to find a name match for this branch
       branches_only_here_.push_back(our_br.name());
     }
-  } // loop over our branches
+  }  // loop over our branches
 
   // check for branches only on the other tree
   for (const BareBranch& their_br : other.branches_) {
     // if branch is should not be ignored AND we couldn't
     // find a match, then this branch is only in the other tree
     if (not shouldIgnore(their_br) and
-        match_found.find(their_br.name()) == match_found.end()
-    ) {
+        match_found.find(their_br.name()) == match_found.end()) {
       other.branches_only_here_.push_back(their_br.name());
-    } // their branch was not found here
-  }   // loop over their branches
+    }  // their branch was not found here
+  }    // loop over their branches
 
   // perfect match is only when all three
   // containers of differences are empty
-  return (branches_only_here_.empty() 
-          and branches_diff_data_.empty() 
-          and other.branches_only_here_.empty());
+  return (branches_only_here_.empty() and branches_diff_data_.empty() and
+          other.branches_only_here_.empty());
 }
 
 std::vector<BareBranch> BareTree::flatBranchList(TObjArray* list) const {
   std::vector<BareBranch> flattened_list;
-  for (unsigned int i=0; i < list->GetEntries(); i++) {
+  for (unsigned int i = 0; i < list->GetEntries(); i++) {
     TBranch* sub_branch = (TBranch*)list->At(i);
     if (sub_branch->GetListOfBranches()->GetEntries() > 0) {
-      //recursion
-      std::vector<BareBranch> sub_list{flatBranchList(sub_branch->GetListOfBranches())};
-      flattened_list.insert( flattened_list.end(), sub_list.begin(), sub_list.end());
+      // recursion
+      std::vector<BareBranch> sub_list{
+          flatBranchList(sub_branch->GetListOfBranches())};
+      flattened_list.insert(flattened_list.end(), sub_list.begin(),
+                            sub_list.end());
     } else {
-      flattened_list.emplace_back(file_,sub_branch);
+      flattened_list.emplace_back(file_, sub_branch);
     }
   }
   return flattened_list;
@@ -101,5 +102,5 @@ bool BareTree::shouldIgnore(const BareBranch& b) const {
   return false;
 }
 
-}
-}
+}  // namespace treediff
+}  // namespace framework

--- a/src/Framework/TreeDiff/BareTree.cxx
+++ b/src/Framework/TreeDiff/BareTree.cxx
@@ -30,6 +30,16 @@ bool BareTree::compare(const BareTree& other) const {
   this->newComparison();
   other.newComparison();
 
+  /**
+   * Check size of the two trees.
+   * If the size differs, issue a warning that the comparison is ill-formed.
+   */
+  if (this->tree_->GetEntriesFast() != other.tree_->GetEntriesFast()) {
+    std::cerr << "[ BareTree ] WARN : Comparing trees of different sizes.\n"
+                 "  This comparison will fail and list all branches as fails!"
+              << std::endl;
+  }
+
   // store branch names where we found a name-match
   // between the trees
   std::set<TString> match_found;

--- a/src/Framework/TreeDiff/Compare.cxx
+++ b/src/Framework/TreeDiff/Compare.cxx
@@ -22,7 +22,16 @@ int compare(const TString& f1, const TString& f2,
      * Can we silence them?
      */
     TFile file_1(f1);
+    if (not file_1.IsOpen()) {
+      EXCEPTION_RAISE("BadFile",
+          ("File '"+f1+"' was not abled to be opened.").Data());
+    }
+
     TFile file_2(f2);
+    if (not file_2.IsOpen()) {
+      EXCEPTION_RAISE("BadFile",
+          ("File '"+f2+"' was not abled to be opened.").Data());
+    }
 
     bool mismatch{false};
     for (auto const& tree_name : trees) {

--- a/src/Framework/TreeDiff/Compare.cxx
+++ b/src/Framework/TreeDiff/Compare.cxx
@@ -32,7 +32,7 @@ int compare(const TString& f1, const TString& f2,
                       ("File '" + f2 + "' was not abled to be opened.").Data());
     }
 
-    bool mismatch{false};
+    int exit_status{MATCH};
     for (auto const& tree_name : trees) {
       BareTree tree_1(&file_1, tree_name, to_ignore);
       BareTree tree_2(&file_2, tree_name, to_ignore);
@@ -43,7 +43,7 @@ int compare(const TString& f1, const TString& f2,
       }
 
       // match not successful, let's print what was wrong
-      mismatch = true;
+      exit_status = MISMATCH;
 
       std::cout << tree_name << " mismatched between files" << std::endl;
       auto only_in_file_1 = tree_1.getBranchesOnlyHere();
@@ -68,10 +68,7 @@ int compare(const TString& f1, const TString& f2,
       std::cout << std::endl;
     }
 
-    if (mismatch)
-      return MISMATCH;
-    else
-      return MATCH;
+    return exit_status;
 
   } catch (framework::exception::Exception& e) {
     std::cerr << "[" << e.name() << "] : " << e.message() << "\n"

--- a/src/Framework/TreeDiff/Compare.cxx
+++ b/src/Framework/TreeDiff/Compare.cxx
@@ -1,0 +1,78 @@
+
+#include <iostream>
+
+#include "TFile.h"
+
+#include "Framework/Exception/Exception.h"
+#include "Framework/TreeDiff/Compare.h"
+#include "Framework/TreeDiff/BareTree.h"
+
+namespace framework {
+namespace treediff {
+
+int compare(const TString& f1, const TString& f2,
+            const std::vector<TString>& trees,
+            const std::vector<TString>& to_ignore) {
+
+  try {
+    /**
+     * Loading the files causes ROOT to print
+     * a lot of 'dictionary not available' warnings.
+     *
+     * Can we silence them?
+     */
+    TFile file_1(f1);
+    TFile file_2(f2);
+
+    bool mismatch{false};
+    for (auto const& tree_name : trees) {
+      BareTree tree_1(&file_1,tree_name,to_ignore);
+      BareTree tree_2(&file_2,tree_name,to_ignore);
+      
+      if (tree_1.compare(tree_2)) {
+        //success! go to next tree immediately
+        continue;
+      }
+
+      // match not successful, let's print what was wrong
+      mismatch = true;
+
+      std::cout << tree_name << " mismatched between files" << std::endl;
+      auto only_in_file_1 = tree_1.getBranchesOnlyHere();
+      if (not only_in_file_1.empty()) {
+        std::cout << "== Branches Only in '" 
+          << file_1.GetName() << "' ==" << std::endl;
+        for (const auto& b : only_in_file_1) std::cout << b << std::endl;
+      }
+  
+      auto only_in_file_2 = tree_2.getBranchesOnlyHere();
+      if (not only_in_file_2.empty()) {
+        std::cout << "== Branches Only in '" 
+          << file_2.GetName() << "' ==" << std::endl;
+        for (const auto& b : only_in_file_2) std::cout << b << std::endl;
+      }
+  
+      auto diff_branches = tree_1.getBranchesDiffData();
+      if (not diff_branches.empty()) {
+        std::cout << "== Branches with different content ==" << std::endl;
+        for (const auto& b : diff_branches) std::cout << b << std::endl;
+      }
+      std::cout << std::endl;
+
+    }
+
+    if (mismatch) return MISMATCH;
+    else return MATCH;
+
+  } catch (framework::exception::Exception& e) {
+    std::cerr << "[" << e.name() << "] : " << e.message() << "\n"
+              << "  at " << e.module() << ":" << e.line() << " in "
+              << e.function() << "\nStack trace: " << std::endl
+              << e.stackTrace();
+    return FAILED_TO_RUN;
+  }
+}
+
+
+}
+}

--- a/src/Framework/TreeDiff/Compare.cxx
+++ b/src/Framework/TreeDiff/Compare.cxx
@@ -1,11 +1,11 @@
 
+#include "Framework/TreeDiff/Compare.h"
+
 #include <iostream>
 
-#include "TFile.h"
-
 #include "Framework/Exception/Exception.h"
-#include "Framework/TreeDiff/Compare.h"
 #include "Framework/TreeDiff/BareTree.h"
+#include "TFile.h"
 
 namespace framework {
 namespace treediff {
@@ -13,7 +13,6 @@ namespace treediff {
 int compare(const TString& f1, const TString& f2,
             const std::vector<TString>& trees,
             const std::vector<TString>& to_ignore) {
-
   try {
     /**
      * Loading the files causes ROOT to print
@@ -24,22 +23,22 @@ int compare(const TString& f1, const TString& f2,
     TFile file_1(f1);
     if (not file_1.IsOpen()) {
       EXCEPTION_RAISE("BadFile",
-          ("File '"+f1+"' was not abled to be opened.").Data());
+                      ("File '" + f1 + "' was not abled to be opened.").Data());
     }
 
     TFile file_2(f2);
     if (not file_2.IsOpen()) {
       EXCEPTION_RAISE("BadFile",
-          ("File '"+f2+"' was not abled to be opened.").Data());
+                      ("File '" + f2 + "' was not abled to be opened.").Data());
     }
 
     bool mismatch{false};
     for (auto const& tree_name : trees) {
-      BareTree tree_1(&file_1,tree_name,to_ignore);
-      BareTree tree_2(&file_2,tree_name,to_ignore);
-      
+      BareTree tree_1(&file_1, tree_name, to_ignore);
+      BareTree tree_2(&file_2, tree_name, to_ignore);
+
       if (tree_1.compare(tree_2)) {
-        //success! go to next tree immediately
+        // success! go to next tree immediately
         continue;
       }
 
@@ -49,29 +48,30 @@ int compare(const TString& f1, const TString& f2,
       std::cout << tree_name << " mismatched between files" << std::endl;
       auto only_in_file_1 = tree_1.getBranchesOnlyHere();
       if (not only_in_file_1.empty()) {
-        std::cout << "== Branches Only in '" 
-          << file_1.GetName() << "' ==" << std::endl;
+        std::cout << "== Branches Only in '" << file_1.GetName()
+                  << "' ==" << std::endl;
         for (const auto& b : only_in_file_1) std::cout << b << std::endl;
       }
-  
+
       auto only_in_file_2 = tree_2.getBranchesOnlyHere();
       if (not only_in_file_2.empty()) {
-        std::cout << "== Branches Only in '" 
-          << file_2.GetName() << "' ==" << std::endl;
+        std::cout << "== Branches Only in '" << file_2.GetName()
+                  << "' ==" << std::endl;
         for (const auto& b : only_in_file_2) std::cout << b << std::endl;
       }
-  
+
       auto diff_branches = tree_1.getBranchesDiffData();
       if (not diff_branches.empty()) {
         std::cout << "== Branches with different content ==" << std::endl;
         for (const auto& b : diff_branches) std::cout << b << std::endl;
       }
       std::cout << std::endl;
-
     }
 
-    if (mismatch) return MISMATCH;
-    else return MATCH;
+    if (mismatch)
+      return MISMATCH;
+    else
+      return MATCH;
 
   } catch (framework::exception::Exception& e) {
     std::cerr << "[" << e.name() << "] : " << e.message() << "\n"
@@ -82,6 +82,5 @@ int compare(const TString& f1, const TString& f2,
   }
 }
 
-
-}
-}
+}  // namespace treediff
+}  // namespace framework

--- a/src/Framework/TreeDiff/tree_diff.cxx
+++ b/src/Framework/TreeDiff/tree_diff.cxx
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 
     auto only_in_file_2 = t2.getBranchesOnlyHere();
     if (not only_in_file_2.empty()) {
-      std::cout << "== Objects Only in '" << file_names.at(1)
+      std::cout << "== Branches Only in '" << file_names.at(1)
                 << "'==" << std::endl;
       for (const auto& b : only_in_file_2) std::cout << b << std::endl;
     }

--- a/src/Framework/TreeDiff/tree_diff.cxx
+++ b/src/Framework/TreeDiff/tree_diff.cxx
@@ -2,33 +2,37 @@
 #include <iostream>
 #include <set>
 
-#include "TString.h"
-
 #include "Framework/Exception/Exception.h"
 #include "Framework/TreeDiff/BareTree.h"
+#include "TString.h"
 
 /**
  * Print the usage of this executable to std::cout
  */
 static inline void usage() {
-  std::cout << "Use: tree-diff [-h,--help] [-i,--ignore class_name]" << std::endl;
+  std::cout << "Use: tree-diff [-h,--help] [-i,--ignore class_name]"
+            << std::endl;
   std::cout << "               -t,--tree tree_name" << std::endl;
   std::cout << "               {file1.root} {file2.root}" << std::endl;
-  std::cout << "  Display the objects that are different between the two input root files." << std::endl;
+  std::cout << "  Display the objects that are different between the two input "
+               "root files."
+            << std::endl;
   std::cout << "-h,--help  Print this help message and exit." << std::endl;
   std::cout << "-i,--ignore" << std::endl;
-  std::cout << "           Name of class to ignore. Can specify more than once." << std::endl;
-  std::cout << "-t,--tree  Define name of tree to compare. REQUIRED." << std::endl;
+  std::cout << "           Name of class to ignore. Can specify more than once."
+            << std::endl;
+  std::cout << "-t,--tree  Define name of tree to compare. REQUIRED."
+            << std::endl;
 }
 
 /**
  * Helper function for configuration error where
  * an input flag isn't provided its required argument.
  */
-static inline void needsArgAfter(const TString &arg) {
+static inline void needsArgAfter(const TString& arg) {
   usage();
-  std::cout << "** Flag " << arg
-    << " requires an argument after it. **" << std::endl;
+  std::cout << "** Flag " << arg << " requires an argument after it. **"
+            << std::endl;
 }
 
 /// return status when executable failed to run
@@ -45,8 +49,10 @@ static const int MISMATCH{1};
  *
  * Compare the difference between the same tree
  * in two separate files.
+ *
+ * @see usage for what the arguments should be
  */
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   std::vector<TString> to_ignore;
   TString tree_name;
   std::vector<TString> file_names;
@@ -56,20 +62,20 @@ int main(int argc, char *argv[]) {
       usage();
       return 0;
     } else if (arg.EqualTo("-i") or arg.EqualTo("--ignore")) {
-      if (arg_i+1 > argc or argv[arg_i+1][0] == '-') {
+      if (arg_i + 1 > argc or argv[arg_i + 1][0] == '-') {
         needsArgAfter(arg);
         return FAILED_TO_RUN;
       }
-      to_ignore.emplace_back(argv[arg_i+1]);
-      //shift arg index to skip name after flag
+      to_ignore.emplace_back(argv[arg_i + 1]);
+      // shift arg index to skip name after flag
       arg_i++;
     } else if (arg.EqualTo("-t") or arg.EqualTo("--tree")) {
-      if (arg_i+1 > argc or argv[arg_i+1][0] == '-') {
+      if (arg_i + 1 > argc or argv[arg_i + 1][0] == '-') {
         needsArgAfter(arg);
         return FAILED_TO_RUN;
       }
-      tree_name = argv[arg_i+1];
-      //shift arg index to skip name after flag
+      tree_name = argv[arg_i + 1];
+      // shift arg index to skip name after flag
       arg_i++;
     } else {
       file_names.push_back(arg);
@@ -87,21 +93,25 @@ int main(int argc, char *argv[]) {
   }
 
   try {
+    /**
+     * Loading the files causes ROOT to print
+     * a lot of 'dictionary not available' warnings.
+     *
+     * Can we silence them?
+     */
     TFile f1(file_names.at(0));
     TFile f2(file_names.at(1));
 
-    framework::treediff::BareTree t1(&f1,tree_name,to_ignore);
-    framework::treediff::BareTree t2(&f2,tree_name,to_ignore);
+    framework::treediff::BareTree t1(&f1, tree_name, to_ignore);
+    framework::treediff::BareTree t2(&f2, tree_name, to_ignore);
 
     if (t1.compare(t2)) {
-      //match successful, leave early
+      // match successful, leave early
       return MATCH;
     }
 
     // match not successful, let's print what was wrong
 
-    // there are some branches that are in one file and not the other
-    //   //      what are these branches?
     auto only_in_file_1 = t1.getBranchesOnlyHere();
     if (not only_in_file_1.empty()) {
       std::cout << "== Branches Only in '" << file_names.at(0)
@@ -127,9 +137,9 @@ int main(int argc, char *argv[]) {
 
   } catch (framework::exception::Exception& e) {
     std::cerr << "[" << e.name() << "] : " << e.message() << "\n"
-      << "  at " << e.module() << ":" << e.line() << " in "
-      << e.function() << "\nStack trace: " << std::endl
-      << e.stackTrace();
+              << "  at " << e.module() << ":" << e.line() << " in "
+              << e.function() << "\nStack trace: " << std::endl
+              << e.stackTrace();
     return FAILED_TO_RUN;
   }
 }

--- a/src/Framework/TreeDiff/tree_diff.cxx
+++ b/src/Framework/TreeDiff/tree_diff.cxx
@@ -2,22 +2,22 @@
 #include <iostream>
 #include <set>
 
-#include "TString.h"
-
 #include "Framework/TreeDiff/Compare.h"
+#include "TString.h"
 
 /**
  * Print the usage of this executable to std::cout
  */
 static inline void usage() {
-  std::cout 
-    << "Use: tree-diff [-h,--help] [-i,--ignore s0]\n"
-    << "               -t,--tree name0 [-t,--tree name1 ...]\n"
-    << "               {file1.root} {file2.root}\n"
-    << "-h,--help  Print this help message and exit.\n"
-    << "-i,--ignore\n"
-    << "           Substrings of branches to ignore. Can specify more than once.\n"
-    << "-t,--tree  Define name(s) of tree(s) to compare. At least one required.\n";
+  std::cout << "Use: tree-diff [-h,--help] [-i,--ignore s0]\n"
+            << "               -t,--tree name0 [-t,--tree name1 ...]\n"
+            << "               {file1.root} {file2.root}\n"
+            << "-h,--help  Print this help message and exit.\n"
+            << "-i,--ignore\n"
+            << "           Substrings of branches to ignore. Can specify more "
+               "than once.\n"
+            << "-t,--tree  Define name(s) of tree(s) to compare. At least one "
+               "required.\n";
 }
 
 /**
@@ -79,10 +79,11 @@ int main(int argc, char* argv[]) {
 
   if (tree_names.empty()) {
     usage();
-    std::cerr << "** Need to specify at least one tree to compare **" << std::endl;
+    std::cerr << "** Need to specify at least one tree to compare **"
+              << std::endl;
     return framework::treediff::FAILED_TO_RUN;
   }
 
-  return framework::treediff::compare(file_names.at(0), file_names.at(1), 
-      tree_names, to_ignore);
+  return framework::treediff::compare(file_names.at(0), file_names.at(1),
+                                      tree_names, to_ignore);
 }

--- a/src/Framework/TreeDiff/tree_diff.cxx
+++ b/src/Framework/TreeDiff/tree_diff.cxx
@@ -1,0 +1,123 @@
+
+#include <iostream>
+#include <set>
+
+#include "TString.h"
+
+#include "Framework/Exception/Exception.h"
+#include "Framework/TreeDiff/BareTree.h"
+
+static inline void usage() {
+  std::cout << "Use: root-diff [-h,--help] [-i,--ignore class_name]" << std::endl;
+  std::cout << "               -t,--tree tree_name" << std::endl;
+  std::cout << "               {file1.root} {file2.root}" << std::endl;
+  std::cout << "  Display the objects that are different between the two input root files." << std::endl;
+  std::cout << "-h,--help  Print this help message and exit." << std::endl;
+  std::cout << "-i,--ignore" << std::endl;
+  std::cout << "           Name of class to ignore. Can specify more than once." << std::endl;
+  std::cout << "-t,--tree  Define name of tree to compare. REQUIRED." << std::endl;
+}
+
+static inline void needsArgAfter(const TString &arg) {
+  usage();
+  std::cout << "** Flag " << arg
+    << " requires an argument after it. **" << std::endl;
+}
+
+static const int FAILED_TO_RUN{127};
+static const int MATCH{0};
+static const int MISMATCH{1};
+
+/**
+ * tree-diff
+ *
+ * Compare the difference between the same tree
+ * in two separate files.
+ */
+int main(int argc, char *argv[]) {
+  std::set<TString> ignore_branches;
+  TString tree_name;
+  std::vector<TString> file_names;
+  for (int arg_i{1}; arg_i < argc; arg_i++) {
+    TString arg{argv[arg_i]};
+    if (arg.EqualTo("-h") or arg.EqualTo("--help")) {
+      usage();
+      return 0;
+    } else if (arg.EqualTo("-i") or arg.EqualTo("--ignore")) {
+      if (arg_i+1 > argc) {
+        needsArgAfter(arg);
+        return FAILED_TO_RUN;
+      }
+      ignore_branches.insert(argv[arg_i+1]);
+      //shift arg index to skip name after flag
+      arg_i++;
+    } else if (arg.EqualTo("-t") or arg.EqualTo("--tree")) {
+      if (arg_i+1 > argc) {
+        needsArgAfter(arg);
+        return FAILED_TO_RUN;
+      }
+      tree_name = argv[arg_i+1];
+      //shift arg index to skip name after flag
+      arg_i++;
+    } else {
+      file_names.push_back(arg);
+    }
+  }
+
+  if (file_names.size() != 2) {
+    usage();
+    std::cerr << "** Need to specify exactly two files **" << std::endl;
+  }
+
+  if (tree_name.IsNull()) {
+    usage();
+    std::cerr << "** Need to specify name of TTree to compare **" << std::endl;
+  }
+
+  try {
+    TFile f1(file_names.at(0));
+    TFile f2(file_names.at(1));
+
+    framework::treediff::BareTree t1(&f1,tree_name);
+    framework::treediff::BareTree t2(&f2,tree_name);
+
+    if (t1.compare(t2)) {
+      //match successful, leave early
+      return MATCH;
+    }
+
+    // match not successful, let's print what was wrong
+
+    // there are some branches that are in one file and not the other
+    //   //      what are these branches?
+    auto only_in_file_1 = t1.getBranchesOnlyHere();
+    if (not only_in_file_1.empty()) {
+      std::cout << "== Branches Only in '" << file_names.at(0)
+                << "'==" << std::endl;
+      for (const auto& b : only_in_file_1) std::cout << b << std::endl;
+    }
+
+    auto only_in_file_2 = t2.getBranchesOnlyHere();
+    if (not only_in_file_2.empty()) {
+      std::cout << "== Objects Only in '" << file_names.at(1)
+                << "'==" << std::endl;
+      for (const auto& b : only_in_file_2) std::cout << b << std::endl;
+    }
+
+    auto diff_branches = t1.getBranchesDiffData();
+    if (not diff_branches.empty()) {
+      std::cout << "== Branches with different content ==" << std::endl;
+      for (const auto& b : diff_branches) std::cout << b << std::endl;
+      // optionally make histograms comparing these branches?
+    }
+
+    return MISMATCH;
+
+  } catch (framework::exception::Exception& e) {
+    std::cerr << "[" << e.name() << "] : " << e.message() << "\n"
+      << "  at " << e.module() << ":" << e.line() << " in "
+      << e.function() << "\nStack trace: " << std::endl
+      << e.stackTrace();
+    return FAILED_TO_RUN;
+  }
+}

--- a/src/Framework/TreeDiff/tree_diff.cxx
+++ b/src/Framework/TreeDiff/tree_diff.cxx
@@ -11,14 +11,13 @@
  */
 static inline void usage() {
   std::cout 
-    << "Use: tree-diff [-h,--help] [-i,--ignore class_name]"
-    << "               -t,--tree tree_name\n"
+    << "Use: tree-diff [-h,--help] [-i,--ignore s0]\n"
+    << "               -t,--tree name0 [-t,--tree name1 ...]\n"
     << "               {file1.root} {file2.root}\n"
     << "-h,--help  Print this help message and exit.\n"
     << "-i,--ignore\n"
-    << "           Name of class to ignore. Can specify more than once.\n"
-    << "-t,--tree  Define name of tree to compare. One or more required.\n"
-    << std::endl;
+    << "           Substrings of branches to ignore. Can specify more than once.\n"
+    << "-t,--tree  Define name(s) of tree(s) to compare. At least one required.\n";
 }
 
 /**
@@ -71,12 +70,17 @@ int main(int argc, char* argv[]) {
 
   if (file_names.size() != 2) {
     usage();
+    std::cerr << "Files Given: ";
+    for (auto const& f : file_names) std::cerr << f << " ";
+    std::cerr << std::endl;
     std::cerr << "** Need to specify exactly two files **" << std::endl;
+    return framework::treediff::FAILED_TO_RUN;
   }
 
   if (tree_names.empty()) {
     usage();
-    std::cerr << "** Need to specify at least one TTree to compare **" << std::endl;
+    std::cerr << "** Need to specify at least one tree to compare **" << std::endl;
+    return framework::treediff::FAILED_TO_RUN;
   }
 
   return framework::treediff::compare(file_names.at(0), file_names.at(1), 

--- a/src/Framework/TreeDiff/tree_diff.cxx
+++ b/src/Framework/TreeDiff/tree_diff.cxx
@@ -2,27 +2,23 @@
 #include <iostream>
 #include <set>
 
-#include "Framework/Exception/Exception.h"
-#include "Framework/TreeDiff/BareTree.h"
 #include "TString.h"
+
+#include "Framework/TreeDiff/Compare.h"
 
 /**
  * Print the usage of this executable to std::cout
  */
 static inline void usage() {
-  std::cout << "Use: tree-diff [-h,--help] [-i,--ignore class_name]"
-            << std::endl;
-  std::cout << "               -t,--tree tree_name" << std::endl;
-  std::cout << "               {file1.root} {file2.root}" << std::endl;
-  std::cout << "  Display the objects that are different between the two input "
-               "root files."
-            << std::endl;
-  std::cout << "-h,--help  Print this help message and exit." << std::endl;
-  std::cout << "-i,--ignore" << std::endl;
-  std::cout << "           Name of class to ignore. Can specify more than once."
-            << std::endl;
-  std::cout << "-t,--tree  Define name of tree to compare. REQUIRED."
-            << std::endl;
+  std::cout 
+    << "Use: tree-diff [-h,--help] [-i,--ignore class_name]"
+    << "               -t,--tree tree_name\n"
+    << "               {file1.root} {file2.root}\n"
+    << "-h,--help  Print this help message and exit.\n"
+    << "-i,--ignore\n"
+    << "           Name of class to ignore. Can specify more than once.\n"
+    << "-t,--tree  Define name of tree to compare. One or more required.\n"
+    << std::endl;
 }
 
 /**
@@ -35,26 +31,17 @@ static inline void needsArgAfter(const TString& arg) {
             << std::endl;
 }
 
-/// return status when executable failed to run
-static const int FAILED_TO_RUN{127};
-
-/// return status for a perfect match
-static const int MATCH{0};
-
-/// return status for a successful run but failed match
-static const int MISMATCH{1};
-
 /**
  * tree-diff
  *
- * Compare the difference between the same tree
+ * Compare the difference between trees
  * in two separate files.
  *
  * @see usage for what the arguments should be
  */
 int main(int argc, char* argv[]) {
   std::vector<TString> to_ignore;
-  TString tree_name;
+  std::vector<TString> tree_names;
   std::vector<TString> file_names;
   for (int arg_i{1}; arg_i < argc; arg_i++) {
     TString arg{argv[arg_i]};
@@ -64,7 +51,7 @@ int main(int argc, char* argv[]) {
     } else if (arg.EqualTo("-i") or arg.EqualTo("--ignore")) {
       if (arg_i + 1 > argc or argv[arg_i + 1][0] == '-') {
         needsArgAfter(arg);
-        return FAILED_TO_RUN;
+        return framework::treediff::FAILED_TO_RUN;
       }
       to_ignore.emplace_back(argv[arg_i + 1]);
       // shift arg index to skip name after flag
@@ -72,9 +59,9 @@ int main(int argc, char* argv[]) {
     } else if (arg.EqualTo("-t") or arg.EqualTo("--tree")) {
       if (arg_i + 1 > argc or argv[arg_i + 1][0] == '-') {
         needsArgAfter(arg);
-        return FAILED_TO_RUN;
+        return framework::treediff::FAILED_TO_RUN;
       }
-      tree_name = argv[arg_i + 1];
+      tree_names.emplace_back(argv[arg_i + 1]);
       // shift arg index to skip name after flag
       arg_i++;
     } else {
@@ -87,59 +74,11 @@ int main(int argc, char* argv[]) {
     std::cerr << "** Need to specify exactly two files **" << std::endl;
   }
 
-  if (tree_name.IsNull()) {
+  if (tree_names.empty()) {
     usage();
-    std::cerr << "** Need to specify name of TTree to compare **" << std::endl;
+    std::cerr << "** Need to specify at least one TTree to compare **" << std::endl;
   }
 
-  try {
-    /**
-     * Loading the files causes ROOT to print
-     * a lot of 'dictionary not available' warnings.
-     *
-     * Can we silence them?
-     */
-    TFile f1(file_names.at(0));
-    TFile f2(file_names.at(1));
-
-    framework::treediff::BareTree t1(&f1, tree_name, to_ignore);
-    framework::treediff::BareTree t2(&f2, tree_name, to_ignore);
-
-    if (t1.compare(t2)) {
-      // match successful, leave early
-      return MATCH;
-    }
-
-    // match not successful, let's print what was wrong
-
-    auto only_in_file_1 = t1.getBranchesOnlyHere();
-    if (not only_in_file_1.empty()) {
-      std::cout << "== Branches Only in '" << file_names.at(0)
-                << "'==" << std::endl;
-      for (const auto& b : only_in_file_1) std::cout << b << std::endl;
-    }
-
-    auto only_in_file_2 = t2.getBranchesOnlyHere();
-    if (not only_in_file_2.empty()) {
-      std::cout << "== Branches Only in '" << file_names.at(1)
-                << "'==" << std::endl;
-      for (const auto& b : only_in_file_2) std::cout << b << std::endl;
-    }
-
-    auto diff_branches = t1.getBranchesDiffData();
-    if (not diff_branches.empty()) {
-      std::cout << "== Branches with different content ==" << std::endl;
-      for (const auto& b : diff_branches) std::cout << b << std::endl;
-      // optionally make histograms comparing these branches?
-    }
-
-    return MISMATCH;
-
-  } catch (framework::exception::Exception& e) {
-    std::cerr << "[" << e.name() << "] : " << e.message() << "\n"
-              << "  at " << e.module() << ":" << e.line() << " in "
-              << e.function() << "\nStack trace: " << std::endl
-              << e.stackTrace();
-    return FAILED_TO_RUN;
-  }
+  return framework::treediff::compare(file_names.at(0), file_names.at(1), 
+      tree_names, to_ignore);
 }


### PR DESCRIPTION
I have written an extension to Framework that was inspired by [cooperative-computing-lab/root-diff](https://github.com/cooperative-computing-lab/root-diff) which was focused on the more general case of root files with any objects in them. I have specialized this method to look at TTrees of the same name stored in two separate ROOT files.

## Why?

I want to be able to check that my developments only change things I want them to change. One of the most direct ways to do this is to compare the output files to make sure that the final output has not been modified after some code changes. This method allows me to do this comparison while leaving the contents of the different branches of our trees in their serialized form. This "lower-level" comparison has the following benefits.

1. Speed - Only looking at decompressed buffers instead of having to create all of the hierarchical objects really speeds up the comparison.
2. Robust - Comparing the decompressed buffers directly is less prone to bugs compared to having to define a comparison method for each of our event object types.
3. Flexibility - We won't have to change the comparison code when adding/moving/changing event objects. The comparison code will notice that objects have changed, but it won't break.

## What?

This is a pretty light extension. The core of the comparison tool is found in the `TreeDiff` submodule which is newly added. The main user-facing element are two new executables.

1. `tree-diff` : This executable is **only** linked to `Framework::TreeDiff` and is incredibly light weight. The user provides it the two file paths and the tree name(s) to compare and it will report which branches are missing from either tree and which ones have different content.
2. `test-fire` : This executable is setting us up for more robust automatic testing. The user provides this executable a config script and the output file the config script is supposed to generate. Then the program runs the config and compares the output file to the provided output file to see if the config script still generates the same stuff. Right now, the config script is _required_ to _only_ have one command-line argument which is the path to the output file. An example is helpful for understanding:
```bash
# this will tell config.py to write the output into output.root
ldmx fire config.py output.root
# this will compare config.py's output (which will be output.root.test) to the output it's supposed to be in output.root
ldmx test-fire config.py output.root
```
A simple way of setting up the config script so it is ready for testing is to define the output file like so
```python
import sys
p.outputFiles = [sys.argv[1]]
```

## How?
You'll have to read my _excellent_ documentation for this. ;)

 