### PR TITLE
Switch from setting ientry to using nextEvent in a loop

### DIFF
--- a/src/Framework/EventFile.cxx
+++ b/src/Framework/EventFile.cxx
@@ -203,7 +203,12 @@ bool EventFile::nextEvent(bool storeCurrentEvent) {
       if (ientry_ + 1 >= entries_) {
         if (isLoopable_) {
           // reset the event counter: reuse events from start of pileup tree
-          ientry_ = -1;
+          ientry_ = -1; //happens in onEndOfFile() too, but, still needed here
+          if (event_) {
+            event_->onEndOfFile();
+            this->setupEvent(event_);
+          }
+
         } else
           return false;
       }

--- a/src/Framework/EventFile.cxx
+++ b/src/Framework/EventFile.cxx
@@ -245,9 +245,10 @@ void EventFile::setupEvent(Event *evt) {
 int EventFile::skipToEvent(int offset) {
   // make sure the event number exists,
   // -1 to account for stepping in nextEvent()
-  ientry_ = offset % entries_ - 1;
-  if (!this->nextEvent())
-    return -1;
+  offset = offset % entries_ - 1;
+  for (int i_shift{0}; i_shift < offset; i_shift++) {
+    if (!this->nextEvent()) return -1;
+  }
   return ientry_;
 }
 


### PR DESCRIPTION
This fix to `skipToEvent(offset)` switches from setting `ientry_ = offset` to looping using `nextEvent()` `offset` times. Apparently the actual event counter doesn't budge if `ientry_` is just directly updated.

This important bugfix should go in before the real release, preferably along with a fix to randomization of the beam electron position (currently all runs are seeded identically). 

Should close #42 