### PR TITLE
Don't sort vectors

### DIFF
--- a/include/Framework/Bus.h
+++ b/include/Framework/Bus.h
@@ -676,11 +676,11 @@ class Bus {
      * of vectors have the operator< defined.
      *
      * @param t Unused, only helping compiler choose the correct method
-     */
     template <typename Content>
     void post_update(the_type<std::vector<Content>> t) {
       std::sort(baggage_->begin(), baggage_->end());
     }
+     */
 
    private: //specializations of stream
     /**


### PR DESCRIPTION
I forget why I went to the trouble of implementing this, but it should not be a thing, especially since we will be keeping buffers as vectors of ints on the event bus.