### PR TITLE
explicitly tell ROOT not to touch our :shit:

### DIFF
--- a/include/Framework/Bus.h
+++ b/include/Framework/Bus.h
@@ -439,6 +439,9 @@ class Bus {
       if (branch) {
         // branch already exists
         //  set the object the branch should read/write from/to
+        if (dynamic_cast<TBranchElement*>(branch)) {
+          branch->SetBit(TBranchElement::EStatusBits::kDeleteObject, false);
+        }
         branch->SetObject(baggage_);
       } else if (can_create) {
         // branch doesnt exist and we are allowed to make a new one


### PR DESCRIPTION
ROOT wants to call ReleaseObject if the kDeleteObject status bit is set. ReleaseObject deletes the object so a new one can be created when necessary without leaking memory. The problem is that we _don't want_ ROOT to delete our stuff because we want to be able to pass around references like adult C++ coders.

This was discovered while investigating https://github.com/LDMX-Software/ldmx-sw/issues/1111 .

I don't know why this extra delete only matters in overlay but I'm guessing it has something to do with the fact that OverlayProducer actually uses more memory. The ordering and logging stuff that silently avoids this bug is also confusing, but again memory handling is hard stuff.