### PR TITLE
Update default electron count from -1 to 1

### DIFF
--- a/include/Framework/Event.h
+++ b/include/Framework/Event.h
@@ -512,7 +512,7 @@ class Event {
   TTree *inputTree_{nullptr};
 
   /// The total number of electrons in the event
-  int electronCount_{-1}; 
+  int electronCount_{1}; 
 
   /**
    * The Bus


### PR DESCRIPTION
... which is the default/baseline mode of our simulation.

This is first of all the sensible default, second it avoids having to explicitly call the electron counter and use that processor to set the electron count to 1, which is then pulled in `simpleTrigger`. The electron counter can still be used when we want to do something non-standard (use the counted number of electrons and not the simulated, or on multi-e events, etc).