### PR TITLE
fix up run header retrieving procedure

### DIFF
--- a/include/Framework/EventFile.h
+++ b/include/Framework/EventFile.h
@@ -214,6 +214,14 @@ class EventFile {
   void writeRunHeader(ldmx::RunHeader &runHeader);
 
   /**
+   * Update the RunHeader for a given run, if it exists in the input file.
+   * @param[in] runNumber The run number.
+   * @param[in,out] header pointer that should be reset to the one for the input run number
+   * @return true if run header was found, false otherwise
+   */
+  bool updateRunHeader(int runNumber, ldmx::RunHeader* runHeader);
+
+  /**
    * Get the RunHeader for a given run, if it exists in the input file.
    * @param runNumber The run number.
    * @return The RunHeader from the input file.

--- a/include/Framework/Process.h
+++ b/include/Framework/Process.h
@@ -215,7 +215,7 @@ class Process {
   const ldmx::EventHeader *eventHeader_{0};
 
   /** Pointer to the current RunHeader, used for Conditions information */
-  const ldmx::RunHeader *runHeader_{0};
+  ldmx::RunHeader *runHeader_{0};
 
   /** TFile for histograms and other user products */
   TFile *histoTFile_{0};

--- a/src/Framework/EventFile.cxx
+++ b/src/Framework/EventFile.cxx
@@ -351,14 +351,22 @@ void EventFile::writeRunHeader(ldmx::RunHeader &runHeader) {
   return;
 }
 
-ldmx::RunHeader &EventFile::getRunHeader(int runNumber) {
+bool EventFile::updateRunHeader(int runNumber, ldmx::RunHeader* runHeader) {
   if (runMap_.find(runNumber) != runMap_.end()) {
-    return *(runMap_.at(runNumber).second);
-  } else {
-    EXCEPTION_RAISE("DataError", "No run header exists for " +
-                                     std::to_string(runNumber) +
-                                     " in the run map.");
+    runHeader = runMap_.at(runNumber).second;
+    return true;
   }
+  return false;
+}
+
+ldmx::RunHeader& EventFile::getRunHeader(int runNumber) {
+  ldmx::RunHeader* rh{nullptr};
+  if (this->updateRunHeader(runNumber, rh)) {
+    return *rh;
+  }
+  EXCEPTION_RAISE("RunHeader",
+      "Unable to find header for run "
+      +std::to_string(runNumber));
 }
 
 void EventFile::importRunHeaders() {

--- a/src/Framework/Process.cxx
+++ b/src/Framework/Process.cxx
@@ -270,14 +270,12 @@ void Process::run() {
         // notify for new run if necessary
         if (theEvent.getEventHeader().getRun() != wasRun) {
           wasRun = theEvent.getEventHeader().getRun();
-          try {
-            auto runHeader = masterFile->getRunHeader(wasRun);
-            runHeader_ = &runHeader;  // save current run header for later
+          if (masterFile->updateRunHeader(wasRun, runHeader_)) {
             ldmx_log(info) << "Got new run header from '"
                            << masterFile->getFileName() << "' ...\n"
-                           << runHeader;
-            newRun(runHeader);
-          } catch (const framework::exception::Exception &) {
+                           << *runHeader_;
+            newRun(*runHeader_);
+          } else {
             ldmx_log(warn) << "Run header for run " << wasRun
                            << " was not found!";
           }


### PR DESCRIPTION
This method allows the run header held within `Process::run` to simply be
a pointer to the object held in memory by the `EventFile` object. This
will enable users to update the run header in `beforeNewRun` even during
input-file runs.

In addition, this resolves #32 by using a noexcept function when we are okay with the run header not being found.