### PR TITLE
patch variable name so check is helpful

### DIFF
--- a/src/Framework/ConfigurePython.cxx
+++ b/src/Framework/ConfigurePython.cxx
@@ -48,7 +48,7 @@ static std::string getPyString(PyObject* pyObj) {
  */
 std::string repr(PyObject* obj) {
   PyObject* py_repr = PyObject_Repr(obj);
-  if (repr == nullptr) return "";
+  if (py_repr == nullptr) return "";
   std::string str = getPyString(py_repr);
   Py_XDECREF(py_repr);
   return str;


### PR DESCRIPTION
actually check `py_repr` instead of function handle so that we actually can check if we were able to successfully retrieve the Repr from the Python C API