### PR TITLE
rework storage control decision making it a bit more flexible

### DIFF
--- a/include/Framework/EventProcessor.h
+++ b/include/Framework/EventProcessor.h
@@ -157,7 +157,7 @@ class EventProcessor {
    * module
    * @param controlhint The storage control hint to apply for the given event
    */
-  void setStorageHint(framework::StorageControlHint hint) {
+  void setStorageHint(framework::StorageControl::Hint hint) {
     setStorageHint(hint, "");
   }
 
@@ -167,7 +167,7 @@ class EventProcessor {
    * @param purposeString A purpose string which can be used in the skim control
    * configuration
    */
-  void setStorageHint(framework::StorageControlHint hint,
+  void setStorageHint(framework::StorageControl::Hint hint,
                       const std::string &purposeString);
 
   /**

--- a/include/Framework/StorageControl.h
+++ b/include/Framework/StorageControl.h
@@ -64,8 +64,15 @@ class StorageControl {
   /**
    * Determine if the current event should be kept, based on the defined rules
    *
-   * @note If event_completed is false, we don't listen to **anything** and
-   * decide not to keep the event.
+   * Separating the 'must' keywords into their own tier helps give them
+   * greater importance that reflects their name. In order, the decision
+   * follows the criteria below only using hints that match one of the
+   * listening rules configured for the process.
+   * 
+   * 1. If any hint is mustDrop, drop the event.
+   * 2. If any hint is mustKeep (without any mustDrop), keep the event.
+   * 3. Simple majority decision of votes made for keep and drop.
+   * 4. The default decision is made in the event of a tie (or no votes).
    *
    * @param[in] event_completed did we complete processing of the current event?
    * @returns true if we should store the current event into the output file
@@ -109,7 +116,7 @@ class StorageControl {
    * operations.
    */
   struct Rule {
-    bool matches(const Hint& h);
+    bool matches(const Hint& h) const;
 
     /**
      * Event Processor Regex

--- a/src/Framework/EventProcessor.cxx
+++ b/src/Framework/EventProcessor.cxx
@@ -30,7 +30,7 @@ TDirectory *EventProcessor::getHistoDirectory() {
   return histoDir_;
 }
 
-void EventProcessor::setStorageHint(framework::StorageControlHint hint,
+void EventProcessor::setStorageHint(framework::StorageControl::Hint hint,
                                     const std::string &purposeString) {
   process_.getStorageController().addHint(name_, hint, purposeString);
 }

--- a/src/Framework/StorageControl.cxx
+++ b/src/Framework/StorageControl.cxx
@@ -1,5 +1,6 @@
 #include "Framework/StorageControl.h"
 #include <regex.h>
+#include <algorithm>
 #include <sys/types.h>
 #include "Framework/Exception/Exception.h"
 
@@ -48,7 +49,7 @@ void StorageControl::addRule(const std::string& processor_pat,
   rules_.back().purposePattern_ = purpose_pat;
 }
 
-bool StorageControl::Rule::matches(const StorageControl::Hint& h) {
+bool StorageControl::Rule::matches(const StorageControl::Hint& h) const {
   if (regexec((const regex_t*)(evpNameRegex_), h.evpName_.c_str(), 0, 0, 0))
     return false;
   if (purposeRegex_ != 0 &&
@@ -58,28 +59,70 @@ bool StorageControl::Rule::matches(const StorageControl::Hint& h) {
 }
 
 bool StorageControl::keepEvent(bool event_completed) const {
+  /**
+   * @note If event_completed is false, we don't listen to **anything** and
+   * decide not to keep the event.
+   */
   if (not event_completed) return false;
 
+  /**
+   * loop over the hints provided by processors,
+   * if a hint matches any of the rules configured,
+   * we will listen to it.
+   */
   int votesKeep(0), votesDrop(0);
-  // loop over all rules and then over all hints
-  for (auto rule : rules_) {
-    for (auto hint : hints_) {
-      if (!rule.matches(hint)) continue;
-      if (hint.hint_ == hint_shouldKeep || hint.hint_ == hint_mustKeep)
-        votesKeep++;
-      else if (hint.hint_ == hint_shouldDrop || hint.hint_ == hint_mustDrop)
-        votesDrop++;
+  bool mustDrop{false}, mustKeep{false};
+  for (auto hint : hints_) {
+    if (std::any_of(rules_.begin(), rules_.end(), [&hint](const Rule& r) { return r.matches(hint); })) {
+      switch(hint.hint_) {
+        case hint_mustDrop:
+          mustDrop = true;
+          break;
+        case hint_mustKeep:
+          mustKeep = true;
+          break;
+        case hint_shouldDrop:
+          votesDrop++;
+          break;
+        case hint_shouldKeep:
+          votesKeep++;
+          break;
+        case hint_Undefined:
+        case hint_NoOpinion:
+          break;
+        default:
+          // how did I get here?
+          EXCEPTION_RAISE(
+              "SupaBad",
+              "This error comes from StorageControl and should never happen. "
+              "A storage hint should always be one of the members of the StorageControlHint enum."
+          );
+      }
     }
   }
 
-  // easy case
-  if (!votesKeep && !votesDrop) return defaultIsKeep_;
+  /**
+   * mustDrop is highest priority, if it exists the event is dropped
+   */
+  if (mustDrop) return false;
 
-  // harder cases
+  /**
+   * mustKeep is second highest, if it exists when mustDrop does not, the event is kept
+   */
+  if (mustKeep) return true;
+
+  /**
+   * If we don't have any 'must' hints, we tally votes
+   * and follow the choice made by a simple majority.
+   */
   if (votesKeep > votesDrop) return true;
   if (votesDrop > votesKeep) return false;
 
-  // at the end, go with the default
+  /**
+   * If there is a tie in the vote (including the case
+   * where there were no votes), then we use the default
+   * decision.
+   */
   return defaultIsKeep_;
 }
 }  // namespace framework

--- a/test/FunctionalCoreTest.cxx
+++ b/test/FunctionalCoreTest.cxx
@@ -91,7 +91,7 @@ class TestProducer : public Producer {
     float test_float = i_event * 0.1;
     REQUIRE_NOTHROW(event.add("EventTenth", test_float));
 
-    if (res.passesVeto()) setStorageHint(hint_mustKeep);
+    if (res.passesVeto()) setStorageHint(StorageControl::Hint::MustKeep);
 
     return;
   }


### PR DESCRIPTION
Separating the 'must' keywords into their own tier helps give them greater importance that reflects their name. In order, the decision follows the criteria below only using hints that match one of the listening rules configured for the process.

1. If any hint is mustDrop, drop the event.
2. If any hint is mustKeep (without any mustDrop), keep the event.
3. Simple majority decision of votes made for keep and drop.
4. The default decision is made in the event of a tie (or no votes).

This resolves #47 by enabling an "OR" system whereby different processors can use `mustKeep` for events they desire to keep no matter what the other processors decide and `NoOpinion` or `should*` hints when a processor is alright with leaving the decision to other processors in the sequence.