### PR TITLE
move closing of event files into destructor

### DIFF
--- a/include/Framework/EventFile.h
+++ b/include/Framework/EventFile.h
@@ -88,8 +88,12 @@ class EventFile {
   EventFile(const framework::config::Parameters &params,
             const std::string &fileName);
 
-  /// Defult destructor
-  ~EventFile() = default;
+  /**
+   * Destructor
+   *
+   * Make sure to close the file when we destruct
+   */
+  ~EventFile();
 
   /**
    * Add a rule for dropping collections from the output.
@@ -194,15 +198,6 @@ class EventFile {
   int skipToEvent(int offset);
 
   /**
-   * Close the file, writing the tree to disk if creating an output file.
-   *
-   * Deletes any RunHeaders that this instance of EventFile owns.
-   *
-   * @throw Exception if run tree already exists in output file.
-   */
-  void close();
-
-  /**
    * Write the run header into the run map
    *
    * Any RunHeader passed here is not owned or cleaned up
@@ -212,6 +207,15 @@ class EventFile {
    * @throw Exception if run number is already in run map
    */
   void writeRunHeader(ldmx::RunHeader &runHeader);
+  
+  /**
+   * Write the map of run headers to the file as a TTree of RunHeader.
+   *
+   * Deletes any RunHeaders that this instance of EventFile owns.
+   *
+   * @throw Exception if call this function on a non-output file.
+   */
+  void writeRunTree();
 
   /**
    * Update the RunHeader for a given run, if it exists in the input file.

--- a/src/Framework/Process.cxx
+++ b/src/Framework/Process.cxx
@@ -111,6 +111,11 @@ Process::~Process() {
   for (EventProcessor *ep : sequence_) {
     delete ep;
   }
+  if (histoTFile_) {
+    histoTFile_->Write();
+    delete histoTFile_;
+    histoTFile_ = 0;
+  }
 }
 
 void Process::run() {
@@ -198,7 +203,7 @@ void Process::run() {
 
     runHeader.setRunEnd(std::time(nullptr));
     ldmx_log(info) << runHeader;
-    outFile.close();
+    outFile.writeRunTree();
 
   } else {
     // there are input files
@@ -305,13 +310,11 @@ void Process::run() {
 
       for (auto module : sequence_) module->onFileClose(inFile);
 
-      inFile.close();
-
       // Reset the event in case of multiple input files
       theEvent.onEndOfFile();
 
       if (outFile and !singleOutput) {
-        outFile->close();
+        outFile->writeRunTree();
         delete outFile;
         outFile = nullptr;
       }
@@ -324,7 +327,7 @@ void Process::run() {
     if (outFile) {
       // close outFile
       //  outFile would survive to here in single output mode
-      outFile->close();
+      outFile->writeRunTree();
       delete outFile;
       outFile = nullptr;
     }


### PR DESCRIPTION
This means the file will be closed even during exceptions and so we can notify ROOT to do its cleanup procedures _before_ the unloading of libraries happens.

In order to accomplish this, we needed to move the writing of the run headers into its own function so that it can only be called during intentional (no-exception) closing of the output file.

The good news is that I am pretty confident this will resolve most of the `TClassInfo` issues we observe when throwing an exception during processing. Currently, when an exception is thrown and caught, ROOT attempts a soft exit during library unload and prints out a bunch of warnings/errors since the TStreamerInfo is not available. This obscures the actual exception printout which is at best annoying.

## Proof
I used a [framework-testbench](https://github.com/LDMX-Software/framework-testbench) to write a processor that throws exceptions at various points of processing. When running this processor with another one which puts some random data into the output event tree, we observe the exception-caused TClass error with the current `trunk` on Framework. With the updates on this branch, the exception is caught and printed and no TClass error is seen.

### trunk
```
eichl008@framework-testbench:~$ fire config/exceptions.py produce                                                  
---- LDMXSW: Loading configuration --------
---- LDMXSW: Configuration load complete  --------
---- LDMXSW: Starting event processing --------
 [ Process ] 1 : Processing 1 Run 1 Event 1  (2023-09-28 10:49:49.185664000-0500)
 [ fire ] 4 : [TEST] : produce
  at /export/scratch/users/eichl008/ldmx/framework-testbench/Bench/src/Bench/Exceptions.cxx:39 in produce
Stack trace: 
    0 framework::exception::Exception::Exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11:
:basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 202 
    1 bench::Exceptions::produce(framework::Event&) + 317 
    2 framework::Process::process(int, framework::Event&) const + 703 
    3 framework::Process::run() + 2072 
    4 main + 736 addr2line: 'fire': No such file

    5 /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7fd89bb11d90]
Error in <TClass::LoadClassInfo>: no interpreter information for class TVirtualStreamerInfo is available even though it has a TClass initialization routine.
malloc(): unaligned tcache chunk detected
Aborted (core dumped)
```
While I haven't reproduced it directly, I believe the `TClass::LoadClassInfo` error line is repeated for each branch that is being written to the output event file and output histogram file. This means if I can remove that line, I'd be removing those issues where we get dozens of those lines during ldmx-sw processing exceptions.

### close-files-before-exit
```
eichl008@framework-testbench:~$ fire config/exceptions.py produce ldmx
---- LDMXSW: Loading configuration --------
---- LDMXSW: Configuration load complete  --------
---- LDMXSW: Starting event processing --------
 [ Process ] 1 : Processing 1 Run 1 Event 1  (2023-09-28 12:28:24.763538000-0500)
 [ fire ] 4 : [TEST] : produce
  at /export/scratch/users/eichl008/ldmx/framework-testbench/Bench/src/Bench/Exceptions.cxx:50 in produce
Stack trace: 
    0 framework::exception::Exception::Exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11:
:basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 202 
    1 bench::Exceptions::produce(framework::Event&) + 491 
    2 framework::Process::process(int, framework::Event&) const + 703 
    3 framework::Process::run() + 2072 
    4 main + 736 addr2line: 'fire': No such file

    5 /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ff5d0461d90]
```