### PR TITLE
add a tries member and replace local variable with it

### DIFF
--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -153,7 +153,7 @@ class EventHeader {
    * @param name The name of the parameter.
    * @return The parameter value.
    */
-  int getIntParameter(const std::string& name) { return intParameters_[name]; }
+  int getIntParameter(const std::string& name) const { return intParameters_[name]; }
 
   /**
    * Set an int parameter value.
@@ -170,7 +170,7 @@ class EventHeader {
    * @param name The name of the parameter.
    * @return value The parameter value.
    */
-  float getFloatParameter(const std::string& name) {
+  float getFloatParameter(const std::string& name) const {
     return floatParameters_[name];
   }
 
@@ -188,7 +188,7 @@ class EventHeader {
    * @param name The name of the parameter.
    * @return value The parameter value.
    */
-  std::string getStringParameter(const std::string& name) {
+  std::string getStringParameter(const std::string& name) const {
     return stringParameters_[name];
   }
 

--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -27,7 +27,7 @@ namespace ldmx {
  * The evolution of the EventHeader object has been pretty slow since
  * the `*Parameter* members can be used to hold most additional information.
  * ROOT's serialization infrastructure does define a class version and so
- * the we document the versions here.
+ * we document the versions here.
  *
  * ## v1
  * This was the initial version of the EventHeader and should be considered
@@ -191,7 +191,7 @@ class EventHeader {
   /**
    * Set the event weight.
    * 
-   * The event weight is by default 1. for all events. It is up to
+   * The event weight is by default 1 for all events. It is up to
    * a downstream producer to update the event weight if their procedure
    * demands it (for example, a simulation producer would copy its event
    * weight here).

--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -112,14 +112,14 @@ class EventHeader {
   double getWeight() const { return weight_; }
 
   /**
-   * Increment the number of events tried by one
+   * Set the number of tries it took to generate this event
+   * @note This is used within Framework during Production Mode
+   * and so changing it in a downstream Producer will be confusing
+   * (even if it runs properly).
    *
-   * @note This modification function is used within
-   * Framework during Production Mode (i.e. no input files).
-   * A Producer also incrementing the number of tries during
-   * Production Mode is undefined behavior.
+   * @param[in] t the number of tries
    */
-  void incrementTries() { tries_++; }
+  void setTries(int t) { tries_ = t; }
 
   /**
    * Get the number of events tried

--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -65,42 +65,25 @@ class EventHeader {
   /**
    * Class constructor.
    */
-  EventHeader() {}
+  EventHeader() = default;
 
   /**
    * Class destructor.
    */
-  virtual ~EventHeader() {}
+  virtual ~EventHeader() = default;
 
   /**
    * Clear information from this object.
+   *
+   * @param[in] o ROOT-style Option (ignored)
    */
-  void Clear(Option_t* = "") {
-    eventNumber_ = -1;
-    run_ = -1;
-    timestamp_ = TTimeStamp(0, 0);
-    weight_ = 1.0;
-    tries_ = 0;
-    isRealData_ = false;
-    intParameters_.clear();
-    floatParameters_.clear();
-    stringParameters_.clear();
-  }
+  void Clear(Option_t* o = "");
 
   /**
    * Print this object.
+   * @param[in] o ROOT-style Option (ignored)
    */
-  void Print(Option_t* = "") const {
-    std::cout << "EventHeader {"
-              << " eventNumber: " << eventNumber_ << ", run: " << run_
-              << ", timestamp: " << timestamp_ << ", weight: " << weight_
-              << ", tries: " << tries_;
-    if (isRealData_)
-      std::cout << ", DATA";
-    else
-      std::cout << ", MC";
-    std::cout << " }" << std::endl;
-  }
+  void Print(Option_t* o = "") const;
 
   /**
    * Return the event number.
@@ -202,10 +185,11 @@ class EventHeader {
 
   /**
    * Get an int parameter value.
+   * @throw Exception if parameter does not exist
    * @param name The name of the parameter.
    * @return The parameter value.
    */
-  int getIntParameter(const std::string& name) const { return intParameters_[name]; }
+  int getIntParameter(const std::string& name) const;
 
   /**
    * Set an int parameter value.
@@ -219,12 +203,11 @@ class EventHeader {
 
   /**
    * Get a float parameter value.
+   * @throw Exception if parameter does not exist
    * @param name The name of the parameter.
    * @return value The parameter value.
    */
-  float getFloatParameter(const std::string& name) const {
-    return floatParameters_[name];
-  }
+  float getFloatParameter(const std::string& name) const;
 
   /**
    * Set a float parameter value.
@@ -237,12 +220,11 @@ class EventHeader {
 
   /**
    * Get a string parameter value.
+   * @throw Exception if parameter does not exist
    * @param name The name of the parameter.
    * @return value The parameter value.
    */
-  std::string getStringParameter(const std::string& name) const {
-    return stringParameters_[name];
-  }
+  std::string getStringParameter(const std::string& name) const;
 
   /**
    * Set a string parameter value.

--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -49,6 +49,7 @@ class EventHeader {
     run_ = -1;
     timestamp_ = TTimeStamp(0, 0);
     weight_ = 1.0;
+    tries_ = 0;
     isRealData_ = false;
     intParameters_.clear();
     floatParameters_.clear();
@@ -61,7 +62,8 @@ class EventHeader {
   void Print(Option_t* = "") const {
     std::cout << "EventHeader {"
               << " eventNumber: " << eventNumber_ << ", run: " << run_
-              << ", timestamp: " << timestamp_ << ", weight: " << weight_;
+              << ", timestamp: " << timestamp_ << ", weight: " << weight_
+              << ", tries: " << tries_;
     if (isRealData_)
       std::cout << ", DATA";
     else
@@ -94,6 +96,17 @@ class EventHeader {
    * @return The event weight.
    */
   double getWeight() const { return weight_; }
+
+  /**
+   * Increment the number of events tried by one
+   */
+  void incrementTries() { tries_++; }
+
+  /**
+   * Get the number of events tried
+   * @return the number of tries
+   */
+  int getTries() const { return tries_; }
 
   /**
    * Is this a real data event?
@@ -210,6 +223,12 @@ class EventHeader {
   double weight_{1.0};
 
   /**
+   * The number of events that were begun before
+   * this event was generated and accepted by event filtering.
+   */
+  int tries_{0};
+
+  /**
    * Is this event real data?
    */
   bool isRealData_{false};
@@ -232,7 +251,7 @@ class EventHeader {
   /**
    * ROOT class definition.
    */
-  ClassDef(EventHeader, 2);
+  ClassDef(EventHeader, 3);
 };
 
 }  // namespace ldmx

--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -119,7 +119,7 @@ class EventHeader {
    *
    * @param[in] t the number of tries
    */
-  void setTries(int t) { tries_ = t; }
+  void setTries(int tries) { tries_ = tries; }
 
   /**
    * Get the number of events tried

--- a/src/Framework/EventHeader.cxx
+++ b/src/Framework/EventHeader.cxx
@@ -1,6 +1,58 @@
 
 #include "Framework/EventHeader.h"
+#include "Framework/Exception/Exception.h"
+
+ClassImp(ldmx::EventHeader);
 
 namespace ldmx {
 const std::string EventHeader::BRANCH = "EventHeader";
+
+void EventHeader::Clear(Option_t*) {
+  eventNumber_ = -1;
+  run_ = -1;
+  timestamp_ = TTimeStamp(0, 0);
+  weight_ = 1.0;
+  tries_ = 0;
+  isRealData_ = false;
+  intParameters_.clear();
+  floatParameters_.clear();
+  stringParameters_.clear();
+}
+
+void EventHeader::Print(Option_t*) const {
+  std::cout << "EventHeader {"
+            << " eventNumber: " << eventNumber_ << ", run: " << run_
+            << ", timestamp: " << timestamp_ << ", weight: " << weight_
+            << ", tries: " << tries_;
+  if (isRealData_)
+    std::cout << ", DATA";
+  else
+    std::cout << ", MC";
+  std::cout << " }" << std::endl;
+}
+
+int EventHeader::getIntParameter(const std::string& name) const {
+  if (intParameters_.find(name) == intParameters_.end()) {
+    EXCEPTION_RAISE("NoParam",
+        "Parameter '"+name+"' does not exist in the int parameters.");
+  }
+  return intParameters_.at(name);
+}
+
+float EventHeader::getFloatParameter(const std::string& name) const {
+  if (floatParameters_.find(name) == floatParameters_.end()) {
+    EXCEPTION_RAISE("NoParam",
+        "Parameter '"+name+"' does not exist in the float parameters.");
+  }
+  return floatParameters_.at(name);
+}
+
+std::string EventHeader::getStringParameter(const std::string& name) const {
+  if (stringParameters_.find(name) == stringParameters_.end()) {
+    EXCEPTION_RAISE("NoParam",
+        "Parameter '"+name+"' does not exist in the string parameters.");
+  }
+  return stringParameters_.at(name);
+}
+
 }

--- a/src/Framework/Process.cxx
+++ b/src/Framework/Process.cxx
@@ -174,14 +174,12 @@ void Process::run() {
 
     newRun(runHeader);
 
-    int numTries = 0;  // number of tries for the current event number
     while (n_events_processed < eventLimit_) {
       ldmx::EventHeader &eh = theEvent.getEventHeader();
       eh.setRun(runForGeneration_);
       eh.setEventNumber(n_events_processed + 1);
       eh.setTimestamp(TTimeStamp());
-
-      numTries++;
+      eh.incrementTries();
 
       // reset the storage controller state
       storageController_.resetEventState();
@@ -190,10 +188,9 @@ void Process::run() {
 
       outFile.nextEvent(storageController_.keepEvent(completed));
 
-      if (completed or numTries >= maxTries_) {
+      if (completed or eh.getTries() >= maxTries_) {
         n_events_processed++;                 // increment events made
         NtupleManager::getInstance().fill();  // fill ntuples
-        numTries = 0;                         // reset try counter
       }
 
       NtupleManager::getInstance().clear();


### PR DESCRIPTION
Instead of using a local variable in the Process::run production mode code, we simply use the member variable of the event header. This naturally means the number of tries it took to generate any event will be stored alongside the weight in the header.

### Still To Do
- [x] make sure we can still read files generated with EventHeader v2 with this Framework
- [x] see if old Framework can read files generated with EventHeader v3
- [x] document more of EventHeader set/get functions with where/when to use them