### PR TITLE
move numTries storage into run header

### DIFF
--- a/include/Framework/EventHeader.h
+++ b/include/Framework/EventHeader.h
@@ -40,20 +40,6 @@ namespace ldmx {
  * This is the main version currently and has all of the ldmx-sw necessary
  * information except the number of tries it took to generate any given event.
  * This is what motivated the update to v3.
- *
- * ## v3
- * This version includes the number of tries it took to generate an event
- * (from Framework's point of view) and updates the `get*Parameter` functions
- * to be `const` so that they can be accessed from within analyzers.
- *
- * ### v3-v2 Interop
- * The interoperability of the v2 and v3 event headers was studied during
- * the merging process of the v3 updates. You can view the full details
- * on GitHub: https://github.com/LDMX-Software/Framework/pull/80.
- * In summary, reading v3 headers with v2 will print a warning message
- * and write a file that includes an _empty_ `tries_` subbranch. Reading
- * v2 headers with v3 will silently maintain the v2 structure (i.e. there
- * will be no `tries_` subbranch).
  */
 class EventHeader {
  public:
@@ -110,22 +96,6 @@ class EventHeader {
    * @return The event weight.
    */
   double getWeight() const { return weight_; }
-
-  /**
-   * Set the number of tries it took to generate this event
-   * @note This is used within Framework during Production Mode
-   * and so changing it in a downstream Producer will be confusing
-   * (even if it runs properly).
-   *
-   * @param[in] t the number of tries
-   */
-  void setTries(int tries) { tries_ = tries; }
-
-  /**
-   * Get the number of events tried
-   * @return the number of tries
-   */
-  int getTries() const { return tries_; }
 
   /**
    * Is this a real data event?
@@ -257,12 +227,6 @@ class EventHeader {
   double weight_{1.0};
 
   /**
-   * The number of events that were begun before
-   * this event was generated and accepted by event filtering.
-   */
-  int tries_{0};
-
-  /**
    * Is this event real data?
    */
   bool isRealData_{false};
@@ -285,7 +249,7 @@ class EventHeader {
   /**
    * ROOT class definition.
    */
-  ClassDef(EventHeader, 3);
+  ClassDef(EventHeader, 2);
 };
 
 }  // namespace ldmx

--- a/include/Framework/RunHeader.h
+++ b/include/Framework/RunHeader.h
@@ -19,6 +19,37 @@
 
 namespace ldmx {
 
+/**
+ * Run-specific configuration and data stored in its own output TTree alongside the
+ * event TTree in the output file.
+ *
+ * Similar to the EventHeader, the evolution of this object has been pretty slow since
+ * the `*Parameter*` members have been used to hold most of the additional information
+ * (for example, a lot of the simulation configuration information). The versions of
+ * the RunHeader as defined by ROOT's serialization infrastructure are documented here.
+ *
+ * ## v1 
+ * An initial beta version now lost to the sands of time.
+ *
+ * ## v2 and v3
+ * There are no material (serialized data) changes that are different between v2 and
+ * v3, but this version was increased because we moved the Framework repo (and thus
+ * the RunHeader source) from being within ldmx-sw to its own stand-alone repo. With
+ * an abundance of caution (and lack of understanding of what ROOT's dictionary
+ * cares about), we increased the version number.
+ *
+ * ## v4
+ * Add the numTries_ member variable in order to store exactly how many events were
+ * started during the production of the run.
+ *
+ * ### Interop with v3
+ * When reading a file written with v3 RunHeader using software with v4 RunHeader,
+ * the numTries_ member will keep its default value of 0. This is a nice signal
+ * value since it conveys to the user the lack of information. If the user somehow
+ * gets into the situation of reading a v4 RunHeader with v3 software, the numTries_
+ * member is quietly ignored, maintaining the format of the v3 RunHeader in the
+ * resulting output file.
+ */
 class RunHeader {
  public:
   /**

--- a/include/Framework/RunHeader.h
+++ b/include/Framework/RunHeader.h
@@ -33,7 +33,7 @@ class RunHeader {
    *
    * @note This exists for filling the object from a ROOT branch.
    */
-  RunHeader() {}
+  RunHeader() = default;
 
   /** Destructor. */
   virtual ~RunHeader() {}
@@ -87,6 +87,26 @@ class RunHeader {
    * @param[in] runEnd the end time of the run.
    */
   void setRunEnd(const int runEnd) { runEnd_ = runEnd; }
+
+  /**
+   * Get the total number of tries that were done during the production
+   * of this run
+   *
+   * @return the number of tries
+   */
+  int getNumTries() const { return numTries_; }
+
+  /**
+   * Set the total number of tries that were done during the production
+   * of this run
+   *
+   * @note This function is called within framework::Process::run and
+   * so it should not be used elsewhere. Changing the number of tries
+   * during processing is undefined behavior.
+   *
+   * @param[in] numTries the number of tries in this run
+   */
+  void setNumTries(const int numTries) { numTries_ = numTries; }
 
   /**
    * Get an int parameter value.
@@ -208,6 +228,22 @@ class RunHeader {
   int runEnd_{0};
 
   /**
+   * Total number of events that were begun during the production
+   * of this run
+   *
+   * This value is only set at the end of processing so we can faithfully
+   * store the total number of events that were started. In the case where
+   * maxTriesPerEvent is set to 1, this will be the same as the configured
+   * maxEvents during Production Mode. If more than one try per event is allowed,
+   * this will not necessarily be maxEvents since processors could abort an event
+   * causing more than maxEvents to be started. This can be summarized by the
+   * following inequality
+   *
+   * maxEvents <= numTries <= maxEvents*maxTriesPerEvent
+   */
+  int numTries_{0};
+
+  /**
    * git SHA-1 hash associated with the software tag used to generate
    * this file.
    */
@@ -222,7 +258,7 @@ class RunHeader {
   /** Map of string parameters. */
   std::map<std::string, std::string> stringParameters_;
 
-  ClassDef(RunHeader, 3);
+  ClassDef(RunHeader, 4);
 
 };  // RunHeader
 

--- a/src/Framework/EventHeader.cxx
+++ b/src/Framework/EventHeader.cxx
@@ -12,7 +12,6 @@ void EventHeader::Clear(Option_t*) {
   run_ = -1;
   timestamp_ = TTimeStamp(0, 0);
   weight_ = 1.0;
-  tries_ = 0;
   isRealData_ = false;
   intParameters_.clear();
   floatParameters_.clear();
@@ -22,8 +21,7 @@ void EventHeader::Clear(Option_t*) {
 void EventHeader::Print(Option_t*) const {
   std::cout << "EventHeader {"
             << " eventNumber: " << eventNumber_ << ", run: " << run_
-            << ", timestamp: " << timestamp_ << ", weight: " << weight_
-            << ", tries: " << tries_;
+            << ", timestamp: " << timestamp_ << ", weight: " << weight_;
   if (isRealData_)
     std::cout << ", DATA";
   else

--- a/src/Framework/Process.cxx
+++ b/src/Framework/Process.cxx
@@ -182,7 +182,6 @@ void Process::run() {
       eh.setRun(runForGeneration_);
       eh.setEventNumber(n_events_processed + 1);
       eh.setTimestamp(TTimeStamp());
-      eh.setTries(numTries);
 
       // reset the storage controller state
       storageController_.resetEventState();

--- a/src/Framework/Process.cxx
+++ b/src/Framework/Process.cxx
@@ -174,8 +174,10 @@ void Process::run() {
 
     newRun(runHeader);
 
+    int totalTries = 0; // total number of tries for entire run
     int numTries = 0;  // number of tries for the current event number
     while (n_events_processed < eventLimit_) {
+      totalTries++;
       numTries++;
 
       ldmx::EventHeader &eh = theEvent.getEventHeader();
@@ -206,6 +208,7 @@ void Process::run() {
     for (auto module : sequence_) module->onFileClose(outFile);
 
     runHeader.setRunEnd(std::time(nullptr));
+    runHeader.setNumTries(totalTries);
     ldmx_log(info) << runHeader;
     outFile.writeRunTree();
 

--- a/src/Framework/RunHeader.cxx
+++ b/src/Framework/RunHeader.cxx
@@ -14,6 +14,7 @@ RunHeader::RunHeader(int runNumber) : runNumber_(runNumber) {}
 
 void RunHeader::stream(std::ostream &s) const {
   s << "RunHeader { run: " << getRunNumber()
+    << ", numTries: " << getNumTries()
     << ", detectorName: " << getDetectorName()
     << ", description: " << getDescription() << "\n";
   s << "  intParameters: "


### PR DESCRIPTION
As pointed out in the re-opening of #69 , we need to store the number of tries separate from the events since there can be tries that are not connected to a serialized event (ones _after_ the last successful event that ends up in the output file). This update keeps the refactoring to the EventHeader but removes the new version since there are now no changes relative to the current event header outside of the refactoring which is not important to the ROOT dictionary.

I've checked and documented how the new RunHeader interops with the current RunHeader and so this is good to go.