### PR TITLE
add ability of searchProducts to require full-string match

### DIFF
--- a/include/Framework/Event.h
+++ b/include/Framework/Event.h
@@ -89,7 +89,7 @@ class Event {
    *
    * By default (with full_string_match = false), the pattern can match
    * the full string or any substring within it. One can require the pattern
-   * to match teh full string by changing that parameter.
+   * to match the full string by changing that parameter.
    *
    * @param namematch Regular expression to compare with the product name
    * @param passmatch Regular expression to compare with the pass name

--- a/include/Framework/Event.h
+++ b/include/Framework/Event.h
@@ -283,10 +283,9 @@ class Event {
       //if no passName, then find branchName by looking over known products
       if (knownLookups_.find(collectionName)==knownLookups_.end()) {
         //this collectionName hasn't been found before
-        //  wrap collection name in regex specifying that
         //  this collection name is the whole name and not a partial name
-        std::string coll_regex{"^"+collectionName+"$"};
-        auto matches = searchProducts(coll_regex,"","");
+        //  so we search products with a full-string match required
+        auto matches = searchProducts(collectionName,"","",true);
         if (matches.empty()) {
           // no matches found
           EXCEPTION_RAISE("ProductNotFound",

--- a/include/Framework/Event.h
+++ b/include/Framework/Event.h
@@ -83,8 +83,14 @@ class Event {
 
   /**
    * Get a list of products which match the given POSIX-Extended,
-   * case-insenstive regular-expressions. An empty argument is interpreted as
-   * ".*", which matches everything.
+   * case-insenstive regular-expressions.
+   *
+   * An empty argument is interpreted as ".*", which matches everything.
+   *
+   * By default (with full_string_match = false), the pattern can match
+   * the full string or any substring within it. One can require the pattern
+   * to match teh full string by changing that parameter.
+   *
    * @param namematch Regular expression to compare with the product name
    * @param passmatch Regular expression to compare with the pass name
    * @param typematch Regular expression to compare with the type name
@@ -99,17 +105,32 @@ class Event {
   /**
    * Check for the existence of an object or collection with the
    * given name and pass name in the event.
+   *
+   * This function just uses the searchProducts function **while requiring
+   * the input name and pass to match the full string**.
+   *
+   * @see searchProducts for a more flexible method for existence checking.
+   * If you have any situation more complicated than simply checking if a
+   * collection with exactly the input name, it is recommended to use
+   * the searchProducts function directly. Within a processor, one can access
+   * and print the products from a search relatively easily.
+   * ```cpp
+   * auto matches{event.searchProducts("MyCollection","","")};
+   * std::cout << matches.size() << " event objects match pattern" << std::endl;
+   * for (const auto& match : matches) { std::cout << match << std::endl; }
+   * ```
+   * searchProducts returns a list of ProductTag objects that store the name,
+   * pass, and type of the objects matching the search.
+   *
    * @param name Name (label, not class name) given to the object when it was
    * put into the event.
    * @param passName The process pass label which was in use when this object
    * was put into the event, such as "sim" or "rerecov2".
-   * @return True if the object or collection *uniquely* exists in the event.
+   * @param unique true if requiring one and only one matching object,
+   * false if allowing for one or more matching objects
+   * @return True if the object or collection exists in the event.
    */
-  bool exists(const std::string &name, const std::string &passName = "", bool unique = true, bool full_string = false) const;
-
-  bool exists(const std::string& name, bool unique, bool full_string) const {
-    return exists(name, "", unique, full_string);
-  }
+  bool exists(const std::string &name, const std::string &passName = "", bool unique = true) const;
 
   /**
    * Add a drop rule to the list of regex expressions to drop.

--- a/include/Framework/Event.h
+++ b/include/Framework/Event.h
@@ -88,10 +88,13 @@ class Event {
    * @param namematch Regular expression to compare with the product name
    * @param passmatch Regular expression to compare with the pass name
    * @param typematch Regular expression to compare with the type name
+   * @param full_string_match require all non-empty regular expressions to match
+   * the full string and not a sub-string
    */
   std::vector<ProductTag> searchProducts(const std::string &namematch,
                                          const std::string &passmatch,
-                                         const std::string &typematch) const;
+                                         const std::string &typematch,
+                                         bool full_string_match = false) const;
 
   /**
    * Check for the existence of an object or collection with the
@@ -102,8 +105,10 @@ class Event {
    * was put into the event, such as "sim" or "rerecov2".
    * @return True if the object or collection *uniquely* exists in the event.
    */
-  bool exists(const std::string &name, const std::string &passName = "") const {
-    return (searchProducts(name, passName, "").size() == 1);
+  bool exists(const std::string &name, const std::string &passName = "", bool unique = true, bool full_string = false) const;
+
+  bool exists(const std::string& name, bool unique, bool full_string) const {
+    return exists(name, "", unique, full_string);
   }
 
   /**

--- a/src/Framework/Event.cxx
+++ b/src/Framework/Event.cxx
@@ -85,8 +85,9 @@ std::vector<ProductTag> Event::searchProducts(
 }
 
 bool Event::exists(const std::string &name, const std::string &passName,
-    bool unique, bool full_string) const {
-  auto matches = searchProducts(name, passName, "", full_string);
+    bool unique) const {
+  static const bool require_full_string_match = true;
+  auto matches = searchProducts(name, passName, "", require_full_string_match);
   if (unique) return (matches.size() == 1);
   else return (matches.size() > 0);
 }

--- a/src/Framework/ProductTag.cxx
+++ b/src/Framework/ProductTag.cxx
@@ -1,5 +1,5 @@
 #include "Framework/ProductTag.h"
 
 std::ostream& operator<<(std::ostream& s, const framework::ProductTag& pt) {
-  return s << pt.name() << "_" << pt.passname() << "_" << pt.type();
+  return s << "{ name = " << pt.name() << ", pass = " << pt.passname() << ", type = " << pt.type() << "}";
 }


### PR DESCRIPTION
pass on this ability to exists and include a flag on if the existence check should be for uniqueness as well

This does a few updates as discussed in #85 
1. Extends `Event::searchProducts` to allow users to choose whether to match the full-string or to match on sub-strings (the default when calling `Event::searchProducts` directly like it operates now).
2. Require a full-string-match when searching for event products with `Event::exists`
    - This is the behavior that is changing from what is currently being done and may require downstream refactoring.
4. Add a argument to `Event::exists` allowing users to ask for unique existence (the default and current behavior) or non-unique existence